### PR TITLE
Fix build on MSYS2

### DIFF
--- a/gcc/system.h
+++ b/gcc/system.h
@@ -98,6 +98,4 @@ extern void *xrealloc(void *, size_t);
 extern void *xcalloc(size_t, size_t);
 extern char *xstrdup(const char *);
 
-extern void *alloca(size_t);
-
 #endif /* __GCC_SYSTEM_H__ */


### PR DESCRIPTION
This alloca prototype is problematic because on mingw-w64, alloca is defined as a function-like macro in malloc.h, which is included by stdlib.h. I don't know about other platforms are affected, but removing this prototype allowed me to build on MSYS2 and Linux.
