### PR TITLE
Building libgcc on macOS gives clang errors

### DIFF
--- a/libgcc/Makefile
+++ b/libgcc/Makefile
@@ -1,7 +1,7 @@
 CC1 = ../old_agbcc
-CPP = cpp
+CPP = $(DEVKITARM)/bin/arm-none-eabi-cpp
 AS = $(DEVKITARM)/bin/arm-none-eabi-as
-AR = ar
+AR = $(DEVKITARM)/bin/arm-none-eabi-ar
 
 libgcc.a: libgcc1.a libgcc2.a fp-bit.o dp-bit.o
 	$(AR) -x libgcc1.a


### PR DESCRIPTION
This change tells `make` to use devkitARM's compiler instead of clang.