### PR TITLE
Another macOS fix

### DIFF
--- a/libc/Makefile
+++ b/libc/Makefile
@@ -11,7 +11,7 @@ CPPFLAGS := -I ../ginclude -I include -nostdinc -undef \
 -DABORT_PROVIDED -DHAVE_GETTIMEOFDAY -D__thumb__ -DARM_RDI_MONITOR \
 -D__STDC__ -D__GNUC__ -DINTERNAL_NEWLIB -D__USER_LABEL_PREFIX__=
 
-AR := ar
+AR := $(DEVKITARM)/bin/arm-none-eabi-ar
 
 # Clear the default suffixes.
 .SUFFIXES:
@@ -21,7 +21,7 @@ AR := ar
 
 .PHONY: all clean
 
-C_SRCS := $(shell find -iname "*.c" -a ! -iname "mallocr.c")
+C_SRCS := $(shell find . -iname "*.c" -a ! -iname "mallocr.c")
 C_INTRS := $(C_SRCS:%.c=%.i)
 C_OBJS := $(C_SRCS:%.c=%.o) \
 stdlib/mallocr.o stdlib/freer.o stdlib/reallocr.o stdlib/callocr.o \

--- a/libgcc/Makefile
+++ b/libgcc/Makefile
@@ -1,5 +1,5 @@
 CC1 = ../old_agbcc
-CPP = cpp
+CPP = $(DEVKITARM)/bin/arm-none-eabi-cpp
 AS = $(DEVKITARM)/bin/arm-none-eabi-as
 AR = $(DEVKITARM)/bin/arm-none-eabi-ar
 
@@ -23,7 +23,7 @@ libgcc1.a: lib1thumb.asm
 	for name in $(LIB1ASMFUNCS); \
 	do \
 	  echo $${name}; \
-	  clang -E -undef -nostdinc -DL$${name} -x assembler-with-cpp -o $${name}.s lib1thumb.asm; \
+	  $(CPP) -undef -nostdinc -DL$${name} -x assembler-with-cpp -o $${name}.s lib1thumb.asm; \
 	  bash -c 'echo -e ".text\n\t.align\t2, 0\n"' >> $${name}.s ; \
 	  $(AS) -mcpu=arm7tdmi -o $${name}.o $${name}.s; \
 	  rm -f $${name}.s; \
@@ -40,7 +40,7 @@ libgcc2.a: libgcc2.c longlong.h
 	for name in $(LIB2FUNCS); \
 	do \
 	  echo $${name}; \
-	  clang -E -undef -I ../ginclude -nostdinc -DL$${name} -o $${name}.i libgcc2.c; \
+	  $(CPP) -undef -I ../ginclude -nostdinc -DL$${name} -o $${name}.i libgcc2.c; \
 	  $(CC1) -O2 $${name}.i; \
 	  rm -f $${name}.i; \
 	  bash -c 'echo -e ".text\n\t.align\t2, 0\n"' >> $${name}.s ; \
@@ -52,7 +52,7 @@ libgcc2.a: libgcc2.c longlong.h
 	mv tmplibgcc2.a libgcc2.a
 
 fp-bit.o: fp-bit.c
-	clang -E -undef -I ../ginclude -nostdinc -o fp-bit.i fp-bit.c
+	$(CPP) -undef -I ../ginclude -nostdinc -o fp-bit.i fp-bit.c
 	$(CC1) -O2 fp-bit.i
 	rm -f fp-bit.i
 	bash -c 'echo -e ".text\n\t.align\t2, 0\n"' >> fp-bit.s
@@ -60,7 +60,7 @@ fp-bit.o: fp-bit.c
 	rm -f fp-bit.s
 
 dp-bit.o: dp-bit.c
-	clang -E -undef -I ../ginclude -nostdinc -o dp-bit.i dp-bit.c
+	$(CPP) -undef -I ../ginclude -nostdinc -o dp-bit.i dp-bit.c
 	$(CC1) -O2 dp-bit.i
 	rm -f dp-bit.i
 	bash -c 'echo -e ".text\n\t.align\t2, 0\n"' >> dp-bit.s

--- a/libgcc/Makefile
+++ b/libgcc/Makefile
@@ -1,7 +1,7 @@
 CC1 = ../old_agbcc
 CPP = cpp
 AS = $(DEVKITARM)/bin/arm-none-eabi-as
-AR = ar
+AR = $(DEVKITARM)/bin/arm-none-eabi-ar
 
 libgcc.a: libgcc1.a libgcc2.a fp-bit.o dp-bit.o
 	$(AR) -x libgcc1.a
@@ -23,7 +23,7 @@ libgcc1.a: lib1thumb.asm
 	for name in $(LIB1ASMFUNCS); \
 	do \
 	  echo $${name}; \
-	  $(CPP) -undef -nostdinc -DL$${name} -x assembler-with-cpp -o $${name}.s lib1thumb.asm; \
+	  clang -E -undef -nostdinc -DL$${name} -x assembler-with-cpp -o $${name}.s lib1thumb.asm; \
 	  bash -c 'echo -e ".text\n\t.align\t2, 0\n"' >> $${name}.s ; \
 	  $(AS) -mcpu=arm7tdmi -o $${name}.o $${name}.s; \
 	  rm -f $${name}.s; \
@@ -40,7 +40,7 @@ libgcc2.a: libgcc2.c longlong.h
 	for name in $(LIB2FUNCS); \
 	do \
 	  echo $${name}; \
-	  $(CPP) -undef -I ../ginclude -nostdinc -DL$${name} -o $${name}.i libgcc2.c; \
+	  clang -E -undef -I ../ginclude -nostdinc -DL$${name} -o $${name}.i libgcc2.c; \
 	  $(CC1) -O2 $${name}.i; \
 	  rm -f $${name}.i; \
 	  bash -c 'echo -e ".text\n\t.align\t2, 0\n"' >> $${name}.s ; \
@@ -52,7 +52,7 @@ libgcc2.a: libgcc2.c longlong.h
 	mv tmplibgcc2.a libgcc2.a
 
 fp-bit.o: fp-bit.c
-	$(CPP) -undef -I ../ginclude -nostdinc -o fp-bit.i fp-bit.c
+	clang -E -undef -I ../ginclude -nostdinc -o fp-bit.i fp-bit.c
 	$(CC1) -O2 fp-bit.i
 	rm -f fp-bit.i
 	bash -c 'echo -e ".text\n\t.align\t2, 0\n"' >> fp-bit.s
@@ -60,7 +60,7 @@ fp-bit.o: fp-bit.c
 	rm -f fp-bit.s
 
 dp-bit.o: dp-bit.c
-	$(CPP) -undef -I ../ginclude -nostdinc -o dp-bit.i dp-bit.c
+	clang -E -undef -I ../ginclude -nostdinc -o dp-bit.i dp-bit.c
 	$(CC1) -O2 dp-bit.i
 	rm -f dp-bit.i
 	bash -c 'echo -e ".text\n\t.align\t2, 0\n"' >> dp-bit.s


### PR DESCRIPTION
I had 3 issues building on OSX:

- Mac toolchain's AR tool doesn't generate proper libs - the linker complains the index is empty. I fixed this by changing AR = $(DEVKITARM)/bin/arm-none-eabi-ar, this should generate the same result on all systems.

- Mac uses BSD find, while Linux uses GNU find. It seems that BSD find will complain if you don't specify a path before the other arguments. I fixed this by adding the cwd to the call to find-.

- Mac's cpp is clang, which has numerous issues when trying to use it as a preprocessor only. With clang, you need to pass -E, and pipe output, rather than using -o. I fixed this by using CPP = $(DEVKITARM)/bin/arm-none-eabi-cpp, which again will generate the same result on all platforms.