### PR TITLE
install headers into tools/agbcc/include

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,7 @@ if [ "$1" != "" ]; then
     mkdir -p $1/tools/agbcc/lib
     cp agbcc $1/tools/agbcc/bin/
     cp old_agbcc $1/tools/agbcc/bin/
-    cp -R libc/include/ $1/tools/agbcc/ #drop include, because we don't want include/include
+    cp -R libc/include/ $1/tools/agbcc/include
     cp ginclude/* $1/tools/agbcc/include/
     cp libgcc.a $1/tools/agbcc/lib/
     cp libc.a $1/tools/agbcc/lib/


### PR DESCRIPTION
As long as there is not a `/` after include, this should not make a new directory in `tools/agbcc/include/`. Before this, they would be installed into `tools/agbcc` and I would have to move them manually or add `-I tools/agbcc` to the `CPPFLAGS` in the pokeemerald and pokeruby Makefiles.