### PR TITLE
Remove trailing slash to fix macOS compatibility

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,7 @@ if [ "$1" != "" ]; then
     mkdir -p $1/tools/agbcc/lib
     cp agbcc $1/tools/agbcc/bin/
     cp old_agbcc $1/tools/agbcc/bin/
-    cp -R libc/include/ $1/tools/agbcc/ #drop include, because we don't want include/include
+    cp -R libc/include $1/tools/agbcc/ #drop include, because we don't want include/include
     cp ginclude/* $1/tools/agbcc/include/
     cp libgcc.a $1/tools/agbcc/lib/
     cp libc.a $1/tools/agbcc/lib/


### PR DESCRIPTION
BSD utilities on macOS do not ignore trailing slashes in commands, which results in this script incorrectly copying files to /tools/agbcc, rather than the intended /tools/agbcc/include. Removing the trailing slash should prevent this from happening, and allow macOS users to use the tool as intended.