### PR TITLE
Make devkitARM optional

### DIFF
--- a/libc/Makefile
+++ b/libc/Makefile
@@ -1,4 +1,13 @@
-include $(DEVKITARM)/base_tools
+PREFIX		:=	arm-none-eabi-
+
+export CC	:=	$(PREFIX)gcc
+export CXX	:=	$(PREFIX)g++
+export AS	:=	$(PREFIX)as
+export AR	:=	$(PREFIX)gcc-ar
+export OBJCOPY	:=	$(PREFIX)objcopy
+export STRIP	:=	$(PREFIX)strip
+export NM	:=	$(PREFIX)gcc-nm
+export RANLIB	:=	$(PREFIX)gcc-ranlib
 
 SHELL := /bin/bash -o pipefail
 

--- a/libc/Makefile
+++ b/libc/Makefile
@@ -1,17 +1,6 @@
-ifdef DEVKITARM
-include $(DEVKITARM)/base_tools
-else
-PREFIX		:=	arm-none-eabi-
+export AS	:=	arm-none-eabi-as
+export AR	:=	arm-none-eabi-gcc-ar
 
-export CC	:=	$(PREFIX)gcc
-export CXX	:=	$(PREFIX)g++
-export AS	:=	$(PREFIX)as
-export AR	:=	$(PREFIX)gcc-ar
-export OBJCOPY	:=	$(PREFIX)objcopy
-export STRIP	:=	$(PREFIX)strip
-export NM	:=	$(PREFIX)gcc-nm
-export RANLIB	:=	$(PREFIX)gcc-ranlib
-endif
 SHELL := /bin/bash -o pipefail
 
 ASFLAGS := -mcpu=arm7tdmi

--- a/libc/Makefile
+++ b/libc/Makefile
@@ -1,3 +1,4 @@
+export CXX	:= 	arm-none-eabi-g++
 export AS	:=	arm-none-eabi-as
 export AR	:=	arm-none-eabi-gcc-ar
 

--- a/libc/Makefile
+++ b/libc/Makefile
@@ -1,3 +1,6 @@
+ifdef DEVKITARM
+include $(DEVKITARM)/base_tools
+else
 PREFIX		:=	arm-none-eabi-
 
 export CC	:=	$(PREFIX)gcc
@@ -8,7 +11,7 @@ export OBJCOPY	:=	$(PREFIX)objcopy
 export STRIP	:=	$(PREFIX)strip
 export NM	:=	$(PREFIX)gcc-nm
 export RANLIB	:=	$(PREFIX)gcc-ranlib
-
+endif
 SHELL := /bin/bash -o pipefail
 
 ASFLAGS := -mcpu=arm7tdmi

--- a/libc/Makefile
+++ b/libc/Makefile
@@ -1,7 +1,10 @@
+ifdef DEVKITARM
+include $(DEVKITARM)/base_tools
+else
 export CXX	:= 	arm-none-eabi-g++
 export AS	:=	arm-none-eabi-as
 export AR	:=	arm-none-eabi-gcc-ar
-
+endif
 SHELL := /bin/bash -o pipefail
 
 ASFLAGS := -mcpu=arm7tdmi

--- a/libgcc/Makefile
+++ b/libgcc/Makefile
@@ -1,6 +1,10 @@
+ifdef DEVKITARM
+include $(DEVKITARM)/base_tools
+else
 export CXX	:=	arm-none-eabi-g++
 export AS	:=	arm-none-eabi-as
 export AR	:=	arm-none-eabi-gcc-ar
+endif
 CC1 = ../old_agbcc
 
 libgcc.a: libgcc1.a libgcc2.a fp-bit.o dp-bit.o

--- a/libgcc/Makefile
+++ b/libgcc/Makefile
@@ -1,4 +1,13 @@
-include $(DEVKITARM)/base_tools
+PREFIX		:=	arm-none-eabi-
+
+export CC	:=	$(PREFIX)gcc
+export CXX	:=	$(PREFIX)g++
+export AS	:=	$(PREFIX)as
+export AR	:=	$(PREFIX)gcc-ar
+export OBJCOPY	:=	$(PREFIX)objcopy
+export STRIP	:=	$(PREFIX)strip
+export NM	:=	$(PREFIX)gcc-nm
+export RANLIB	:=	$(PREFIX)gcc-ranlib
 CC1 = ../old_agbcc
 
 libgcc.a: libgcc1.a libgcc2.a fp-bit.o dp-bit.o

--- a/libgcc/Makefile
+++ b/libgcc/Makefile
@@ -1,17 +1,6 @@
-ifdef DEVKITARM
-include $(DEVKITARM)/base_tools
-else
-PREFIX		:=	arm-none-eabi-
-
-export CC	:=	$(PREFIX)gcc
-export CXX	:=	$(PREFIX)g++
-export AS	:=	$(PREFIX)as
-export AR	:=	$(PREFIX)gcc-ar
-export OBJCOPY	:=	$(PREFIX)objcopy
-export STRIP	:=	$(PREFIX)strip
-export NM	:=	$(PREFIX)gcc-nm
-export RANLIB	:=	$(PREFIX)gcc-ranlib
-endif
+export CXX	:=	arm-none-eabi-g++
+export AS	:=	arm-none-eabi-as
+export AR	:=	arm-none-eabi-gcc-ar
 CC1 = ../old_agbcc
 
 libgcc.a: libgcc1.a libgcc2.a fp-bit.o dp-bit.o

--- a/libgcc/Makefile
+++ b/libgcc/Makefile
@@ -1,3 +1,6 @@
+ifdef DEVKITARM
+include $(DEVKITARM)/base_tools
+else
 PREFIX		:=	arm-none-eabi-
 
 export CC	:=	$(PREFIX)gcc
@@ -8,6 +11,7 @@ export OBJCOPY	:=	$(PREFIX)objcopy
 export STRIP	:=	$(PREFIX)strip
 export NM	:=	$(PREFIX)gcc-nm
 export RANLIB	:=	$(PREFIX)gcc-ranlib
+endif
 CC1 = ../old_agbcc
 
 libgcc.a: libgcc1.a libgcc2.a fp-bit.o dp-bit.o


### PR DESCRIPTION
This change should not affect anyone currently using devkit. This should enable users to compile without devkit if the arm-none-eabi compiler is present.

Tested working on Windows by Kurausukun with devkit installed
Tested working on 64-bit Debian by FroggestSpirit without devkit after running "sudo apt-get install gcc-arm-none-eabi binutils-arm-none-eabi"