### PR TITLE
add a flag to prevent unnecessary push/pop

### DIFF
--- a/gcc/flags.h
+++ b/gcc/flags.h
@@ -450,3 +450,6 @@ extern enum graph_dump_types graph_dump_format;
 
 /* Nonzero if ASM output should use hex instead of decimal.  */
 extern int flag_hex_asm;
+
+/* Nonzero if prologue bug should be fixed.  */
+extern int flag_prologue_bugfix;

--- a/gcc/thumb.c
+++ b/gcc/thumb.c
@@ -717,8 +717,11 @@ far_jump_used_p()
     rtx insn;
 
 #ifndef OLD_COMPILER
-    if (current_function_has_far_jump)
-        return 1;
+    if (!flag_prologue_bugfix)
+    {
+        if (current_function_has_far_jump)
+            return 1;
+    }
 #endif
 
     for (insn = get_insns(); insn; insn = NEXT_INSN(insn))

--- a/gcc/toplev.c
+++ b/gcc/toplev.c
@@ -584,6 +584,9 @@ int flag_instrument_function_entry_exit = 0;
 /* Use hex instead of decimal in ASM output.  */
 int flag_hex_asm = 0;
 
+/* Fix prologue bug in new compiler.  */
+int flag_prologue_bugfix = 0;
+
 typedef struct
 {
     char *string;
@@ -723,6 +726,13 @@ lang_independent_options f_options[] =
      "Instrument function entry/exit with profiling calls"},
     {"hex-asm", &flag_hex_asm, 1,
      "Use hex instead of decimal in assembly output"},
+#ifndef OLD_COMPILER
+    /* This flag fixes a bug in the newer agbcc version that causes `lr` to be
+       saved onto the stack in functions where it is not necessary. This is
+       needed to produce matching code for certain GBA games.  */
+    {"prologue-bugfix", &flag_prologue_bugfix, 1,
+     "Prevent unnecessary saving of the lr register to the stack"},
+#endif
 };
 
 #define NUM_ELEM(a)  (sizeof (a) / sizeof ((a)[0]))


### PR DESCRIPTION
A number of GBA games (such as Legend of Zelda: A Link to the Past, Pokemon Pinball: Ruby and Sapphire, and Advance Wars) seem to use the newer agbcc compiler, but have a slight when it comes to saving `lr`. agbcc sometimes pushes `lr` onto the stack in leaf functions where it isn't necessary, while old_agbcc does not. Using the `-fprologue-bugfix` flag will revert agbcc to the behavior of old_agbcc in this case.