### PR TITLE
Add support for building agbcc without devkitPro

### DIFF
--- a/libc/Makefile
+++ b/libc/Makefile
@@ -1,4 +1,10 @@
+ifneq (,$(wildcard $(DEVKITARM)/base_tools))
 include $(DEVKITARM)/base_tools
+else
+PREFIX := arm-none-eabi-
+export AR := $(PREFIX)ar
+export AS := $(PREFIX)as
+endif
 
 SHELL := /bin/bash -o pipefail
 

--- a/libc/Makefile
+++ b/libc/Makefile
@@ -1,4 +1,4 @@
-ifneq (,$(wildcard $(DEVKITARM)/base_tools))
+ifneq (,$(wildcard $(DEVKITARM)/bin))
 include $(DEVKITARM)/base_tools
 else
 PREFIX := arm-none-eabi-

--- a/libc/Makefile
+++ b/libc/Makefile
@@ -1,6 +1,15 @@
-ifneq (,$(wildcard $(DEVKITARM)/bin))
-include $(DEVKITARM)/base_tools
+ifneq (,$(DEVKITARM))
+    ifneq (,$(wildcard $(DEVKITARM)/bin))	    
+        include $(DEVKITARM)/base_tools
+        DKA_EXISTS=1
+    else
+        DKA_EXISTS=0
+    endif
 else
+DKA_EXISTS=0
+endif
+
+ifneq ($(DKA_EXISTS),1)
 PREFIX := arm-none-eabi-
 export AR := $(PREFIX)ar
 export AS := $(PREFIX)as

--- a/libgcc/Makefile
+++ b/libgcc/Makefile
@@ -1,4 +1,11 @@
+ifneq (,$(wildcard $(DEVKITARM)/base_tools))
 include $(DEVKITARM)/base_tools
+else
+PREFIX := arm-none-eabi-
+export AR := $(PREFIX)ar
+export AS := $(PREFIX)as
+endif
+
 CC1 = ../old_agbcc
 
 libgcc.a: libgcc1.a libgcc2.a fp-bit.o dp-bit.o

--- a/libgcc/Makefile
+++ b/libgcc/Makefile
@@ -1,4 +1,4 @@
-ifneq (,$(wildcard $(DEVKITARM)/base_tools))
+ifneq (,$(wildcard $(DEVKITARM)/bin))
 include $(DEVKITARM)/base_tools
 else
 PREFIX := arm-none-eabi-

--- a/libgcc/Makefile
+++ b/libgcc/Makefile
@@ -1,6 +1,15 @@
-ifneq (,$(wildcard $(DEVKITARM)/bin))
-include $(DEVKITARM)/base_tools
+ifneq (,$(DEVKITARM))
+    ifneq (,$(wildcard $(DEVKITARM)/bin))	    
+        include $(DEVKITARM)/base_tools
+        DKA_EXISTS=1
+    else
+        DKA_EXISTS=0
+    endif
 else
+DKA_EXISTS=0
+endif
+
+ifneq ($(DKA_EXISTS),1)
 PREFIX := arm-none-eabi-
 export AR := $(PREFIX)ar
 export AS := $(PREFIX)as


### PR DESCRIPTION
Required as per pret/pokeemerald#1274. Making a new PR instead of trying to coordinate with [pret/agbcc#28](pret/agbcc#28).