### PR TITLE
Fix builds on xcode 12+

### DIFF
--- a/gcc/Makefile
+++ b/gcc/Makefile
@@ -24,7 +24,7 @@ VPATH = $(srcdir)
 
 CC = gcc
 
-BASE_CFLAGS = -g -std=gnu11
+BASE_CFLAGS = -g -std=gnu11 -Werror-implicit-function-declaration
 
 INCLUDES = -I. -I$(srcdir)
 

--- a/gcc/toplev.c
+++ b/gcc/toplev.c
@@ -40,6 +40,7 @@
 #include "except.h"
 #include "toplev.h"
 #include "expr.h"
+#include "unistd.h"
 
 #if defined (DWARF2_DEBUGGING_INFO)
 #include "dwarf2out.h"

--- a/gcc_arm/Makefile.in
+++ b/gcc_arm/Makefile.in
@@ -64,7 +64,7 @@ ALLOCA_FINISH = true
 XCFLAGS =
 TCFLAGS =
 # CYGNUS LOCAL nowarnings/law
-CFLAGS = -g 
+CFLAGS = -g -Werror-implicit-function-declaration
 BOOT_CFLAGS = -O2 $(CFLAGS)
 WARN_CFLAGS =
 # END CYGNUS LOCAL

--- a/gcc_arm/config/arm/arm.c
+++ b/gcc_arm/config/arm/arm.c
@@ -38,6 +38,7 @@ Boston, MA 02111-1307, USA.  */
 #include "tree.h"
 #include "expr.h"
 #include "toplev.h"
+#include "recog.h"
 
 /* The maximum number of insns skipped which will be conditionalised if
    possible.  */
@@ -47,7 +48,6 @@ extern FILE *asm_out_file;
 /* Some function declarations.  */
 
 /* CYGNUS LOCAL */
-void arm_increase_location PROTO ((int));
 static int get_prologue_size PROTO ((void));
 /* END CYGNUS LOCAL */
 

--- a/gcc_arm/config/arm/arm.h
+++ b/gcc_arm/config/arm/arm.h
@@ -2215,4 +2215,10 @@ int ok_integer_or_other ();
 /* END CYGNUS LOCAL */
 int s_register_operand (/* register rtx op, enum machine_mode mode */);
 
+void arm_asm_output_label (/*FILE *, char **/);
+void arm_increase_location PARAMS ((int));
+int short_branch PARAMS ((int, int));
+int arm_insn_not_targeted (/* rtx */);
+int arm_backwards_branch PARAMS ((int, int));
+
 #endif /* __ARM_H__ */

--- a/gcc_arm/gcse.c
+++ b/gcc_arm/gcse.c
@@ -5168,9 +5168,8 @@ invalidate_nonnull_info (x, setter)
    This could probably be integrated with global cprop with a little work.  */
 
 void
-delete_null_pointer_checks (f, pass)
+delete_null_pointer_checks (f)
      rtx f;
-     int pass;
 {
   int_list_ptr *s_preds, *s_succs;
   int *num_preds, *num_succs;

--- a/gcc_arm/genoutput.c
+++ b/gcc_arm/genoutput.c
@@ -226,7 +226,7 @@ from the machine description file `md'.  */\n\n");
   printf ("#include \"insn-attr.h\"\n\n");
   printf ("#include \"insn-codes.h\"\n\n");
   printf ("#include \"recog.h\"\n\n");
-
+  printf ("#include \"tree.h\"\n");
   printf ("#include \"output.h\"\n");
 }
 

--- a/gcc_arm/range.c
+++ b/gcc_arm/range.c
@@ -43,6 +43,8 @@ Boston, MA 02111-1307, USA.  */
 #include "range.h"
 #include "toplev.h"
 
+void init_regset_vector	PROTO ((regset *, int, struct obstack *));
+
 extern struct obstack *rtl_obstack;
 
 /* Information that we gather about registers */

--- a/gcc_arm/rtl.h
+++ b/gcc_arm/rtl.h
@@ -1449,6 +1449,9 @@ extern int gcse_main			PROTO ((rtx, FILE *));
 /* END CYGNUS LOCAL */
 #endif
 
+extern void delete_null_pointer_checks PARAMS ((rtx));
+extern void merge_blocks PARAMS ((rtx));
+
 /* In global.c */
 extern void mark_elimination		PROTO ((int, int));
 #ifdef BUFSIZ

--- a/libc/Makefile
+++ b/libc/Makefile
@@ -1,4 +1,10 @@
+ifneq (,$(wildcard $(DEVKITARM)/base_tools))
 include $(DEVKITARM)/base_tools
+else
+PREFIX := arm-none-eabi-
+export AR := $(PREFIX)ar
+export AS := $(PREFIX)as
+endif
 
 SHELL := /bin/bash -o pipefail
 

--- a/libc/Makefile
+++ b/libc/Makefile
@@ -1,4 +1,4 @@
-ifneq (,$(wildcard $(DEVKITARM)/base_tools))
+ifneq (,$(wildcard $(DEVKITARM)/bin))
 include $(DEVKITARM)/base_tools
 else
 PREFIX := arm-none-eabi-

--- a/libc/Makefile
+++ b/libc/Makefile
@@ -1,6 +1,15 @@
-ifneq (,$(wildcard $(DEVKITARM)/bin))
-include $(DEVKITARM)/base_tools
+ifneq (,$(DEVKITARM))
+    ifneq (,$(wildcard $(DEVKITARM)/bin))	    
+        include $(DEVKITARM)/base_tools
+        DKA_EXISTS=1
+    else
+        DKA_EXISTS=0
+    endif
 else
+DKA_EXISTS=0
+endif
+
+ifneq ($(DKA_EXISTS),1)
 PREFIX := arm-none-eabi-
 export AR := $(PREFIX)ar
 export AS := $(PREFIX)as

--- a/libgcc/Makefile
+++ b/libgcc/Makefile
@@ -18,8 +18,8 @@ endif
 CC1 = ../old_agbcc
 
 libgcc.a: libgcc1.a libgcc2.a fp-bit.o dp-bit.o
-	$(AR) -x libgcc1.a
-	$(AR) -x libgcc2.a
+	$(AR) -x libgcc1.a;
+	$(AR) -x libgcc2.a;
 	$(AR) -rc libgcc.a *.o
 
 LIB1ASMFUNCS = _udivsi3 _divsi3 _umodsi3 _modsi3 _dvmd_tls _call_via_rX
@@ -66,19 +66,19 @@ libgcc2.a: libgcc2.c longlong.h
 	mv tmplibgcc2.a libgcc2.a
 
 fp-bit.o: fp-bit.c
-	$(CPP) -undef -I ../ginclude -nostdinc -o fp-bit.i fp-bit.c
+	$(CPP) -undef -I ../ginclude -nostdinc -o fp-bit.i fp-bit.c;
 	$(CC1) -O2 fp-bit.i
 	rm -f fp-bit.i
 	bash -c 'echo -e ".text\n\t.align\t2, 0\n"' >> fp-bit.s
-	$(AS) -mcpu=arm7tdmi -o fp-bit.o fp-bit.s
+	$(AS) -mcpu=arm7tdmi -o fp-bit.o fp-bit.s;
 	rm -f fp-bit.s
 
 dp-bit.o: dp-bit.c
-	$(CPP) -undef -I ../ginclude -nostdinc -o dp-bit.i dp-bit.c
+	$(CPP) -undef -I ../ginclude -nostdinc -o dp-bit.i dp-bit.c;
 	$(CC1) -O2 dp-bit.i
 	rm -f dp-bit.i
 	bash -c 'echo -e ".text\n\t.align\t2, 0\n"' >> dp-bit.s
-	$(AS) -mcpu=arm7tdmi -o dp-bit.o dp-bit.s
+	$(AS) -mcpu=arm7tdmi -o dp-bit.o dp-bit.s;
 	rm -f dp-bit.s
 
 fp-bit.c: fp-bit-base.c

--- a/libgcc/Makefile
+++ b/libgcc/Makefile
@@ -1,4 +1,11 @@
+ifneq (,$(wildcard $(DEVKITARM)/base_tools))
 include $(DEVKITARM)/base_tools
+else
+PREFIX := arm-none-eabi-
+export AR := $(PREFIX)ar
+export AS := $(PREFIX)as
+endif
+
 CC1 = ../old_agbcc
 
 libgcc.a: libgcc1.a libgcc2.a fp-bit.o dp-bit.o

--- a/libgcc/Makefile
+++ b/libgcc/Makefile
@@ -1,4 +1,4 @@
-ifneq (,$(wildcard $(DEVKITARM)/base_tools))
+ifneq (,$(wildcard $(DEVKITARM)/bin))
 include $(DEVKITARM)/base_tools
 else
 PREFIX := arm-none-eabi-

--- a/libgcc/Makefile
+++ b/libgcc/Makefile
@@ -1,6 +1,15 @@
-ifneq (,$(wildcard $(DEVKITARM)/bin))
-include $(DEVKITARM)/base_tools
+ifneq (,$(DEVKITARM))
+    ifneq (,$(wildcard $(DEVKITARM)/bin))	    
+        include $(DEVKITARM)/base_tools
+        DKA_EXISTS=1
+    else
+        DKA_EXISTS=0
+    endif
 else
+DKA_EXISTS=0
+endif
+
+ifneq ($(DKA_EXISTS),1)
 PREFIX := arm-none-eabi-
 export AR := $(PREFIX)ar
 export AS := $(PREFIX)as


### PR DESCRIPTION
Enforce the use of -Werror-implicit-function-declaration for all platforms to catch this. See: https://developer.apple.com/documentation/xcode-release-notes/xcode-12-release-notes