### PR TITLE
Fix #38: Build script fails on macOS

### DIFF
--- a/gcc/Makefile
+++ b/gcc/Makefile
@@ -24,7 +24,7 @@ VPATH = $(srcdir)
 
 CC = gcc
 
-BASE_CFLAGS = -g -std=gnu11
+BASE_CFLAGS = -g -std=gnu11 -Wno-implicit-function-declaration
 
 INCLUDES = -I. -I$(srcdir)
 

--- a/gcc_arm/Makefile.in
+++ b/gcc_arm/Makefile.in
@@ -64,7 +64,7 @@ ALLOCA_FINISH = true
 XCFLAGS =
 TCFLAGS =
 # CYGNUS LOCAL nowarnings/law
-CFLAGS = -g 
+CFLAGS = -g -Wno-implicit-function-declaration
 BOOT_CFLAGS = -O2 $(CFLAGS)
 WARN_CFLAGS =
 # END CYGNUS LOCAL

--- a/libgcc/Makefile
+++ b/libgcc/Makefile
@@ -18,8 +18,8 @@ endif
 CC1 = ../old_agbcc
 
 libgcc.a: libgcc1.a libgcc2.a fp-bit.o dp-bit.o
-	$(AR) -x libgcc1.a
-	$(AR) -x libgcc2.a
+	$(AR) -x libgcc1.a;
+	$(AR) -x libgcc2.a;
 	$(AR) -rc libgcc.a *.o
 
 LIB1ASMFUNCS = _udivsi3 _divsi3 _umodsi3 _modsi3 _dvmd_tls _call_via_rX
@@ -66,19 +66,19 @@ libgcc2.a: libgcc2.c longlong.h
 	mv tmplibgcc2.a libgcc2.a
 
 fp-bit.o: fp-bit.c
-	$(CPP) -undef -I ../ginclude -nostdinc -o fp-bit.i fp-bit.c
+	$(CPP) -undef -I ../ginclude -nostdinc -o fp-bit.i fp-bit.c;
 	$(CC1) -O2 fp-bit.i
 	rm -f fp-bit.i
 	bash -c 'echo -e ".text\n\t.align\t2, 0\n"' >> fp-bit.s
-	$(AS) -mcpu=arm7tdmi -o fp-bit.o fp-bit.s
+	$(AS) -mcpu=arm7tdmi -o fp-bit.o fp-bit.s;
 	rm -f fp-bit.s
 
 dp-bit.o: dp-bit.c
-	$(CPP) -undef -I ../ginclude -nostdinc -o dp-bit.i dp-bit.c
+	$(CPP) -undef -I ../ginclude -nostdinc -o dp-bit.i dp-bit.c;
 	$(CC1) -O2 dp-bit.i
 	rm -f dp-bit.i
 	bash -c 'echo -e ".text\n\t.align\t2, 0\n"' >> dp-bit.s
-	$(AS) -mcpu=arm7tdmi -o dp-bit.o dp-bit.s
+	$(AS) -mcpu=arm7tdmi -o dp-bit.o dp-bit.s;
 	rm -f dp-bit.s
 
 fp-bit.c: fp-bit-base.c


### PR DESCRIPTION
This should make the build script work properly on Catalina and newer again.