### PR TITLE
Install binutils alongside agbcc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ gcc_arm/s-peep
 gcc_arm/s-recog
 gcc_arm/tree-check.h
 
+binutils/binutils-*.tar.xz
+binutils/binutils-*/
+binutils/build/

--- a/binutils/build.sh
+++ b/binutils/build.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+set -e
+
+version=2.37
+shasum=820d9724f020a3e69cb337893a0b63c2db161dadcb0e06fc11dc29eb1e84a32c
+src=binutils-$version
+tarball=binutils-$version.tar.xz
+
+checksum() {
+    test -f "$1" || return 1
+    sha="$(sha256sum "$1" | cut -d ' ' -f 1)"
+    test "$sha" = "$2" || return 1
+    return 0
+}
+
+checksum "$tarball" "$shasum" || wget -c "https://ftp.gnu.org/gnu/binutils/$tarball"
+if ! checksum "$tarball" "$shasum"; then 
+    sha256sum "$tarball" 1>&2
+    echo "Checksum failed!" 1>&2
+    rm -f "$tarball"
+fi
+
+test -d "$src" || tar xf "$tarball"
+mkdir -p build
+cd build
+MAKEINFO=false \
+"../$src/configure" \
+    --prefix= \
+    --target=arm-none-eabi \
+    --disable-nls
+make -j "${NPROC:-$(nproc)}"

--- a/binutils/clean.sh
+++ b/binutils/clean.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+rm -rf binutils-*/
+rm -rf build

--- a/build.sh
+++ b/build.sh
@@ -1,23 +1,26 @@
 #!/bin/sh
 set -e
-CCOPT=
-CXXOPT=
 
-if [ ! -z "$CC" ]; then CCOPT=CC=$CC; fi
-if [ ! -z "$CXX" ]; then CXXOPT=CXX=$CXX; fi
+(cd binutils
+    ./clean.sh
+    ./build.sh
+)
 make -C gcc clean
-make -C gcc old $CCOPT $CXXOPT
+make -C gcc old
 mv gcc/old_agbcc .
 make -C gcc clean
-make -C gcc $CCOPT $CXXOPT
+make -C gcc
 mv gcc/agbcc .
 # not sure if the ARM compiler is the old one or the new one (-DOLD_COMPILER)
-rm -f gcc_arm/config.status gcc_arm/config.cache
-cd gcc_arm && ./configure --target=arm-elf --host=i386-linux-gnu && make cc1 && cd ..
+( cd gcc_arm
+    rm -f config.status config.cache
+    ./configure --target=arm-elf --host=i386-linux-gnu
+    make cc1
+)
 mv gcc_arm/cc1 agbcc_arm
 make -C libgcc clean
-make -C libgcc $CCOPT $CXXOPT
+make -C libgcc
 mv libgcc/libgcc.a .
 make -C libc clean
-make -C libc $CCOPT $CXXOPT
+make -C libc
 mv libc/libc.a .

--- a/gcc/Makefile
+++ b/gcc/Makefile
@@ -22,7 +22,7 @@
 srcdir = .
 VPATH = $(srcdir)
 
-CC = gcc
+CC ?= gcc
 
 BASE_CFLAGS = -g -std=gnu11 -Werror-implicit-function-declaration
 

--- a/install.sh
+++ b/install.sh
@@ -1,12 +1,23 @@
 #!/bin/sh
 set -e
-if [ "$1" != "" ]; then
-    dest="$(realpath "$1/tools/agbcc")"
-    install -Dm755 -t "$dest/bin" agbcc old_agbcc agbcc_arm
-    install -Dm644 -t "$dest/lib" libgcc.a libc.a
-    install -Dm644 -t "$dest/include" ginclude/*
-    cp -R libc/include "$dest/" #drop include, because we don't want include/include
-    make -C binutils/build DESTDIR="$dest" install
+
+default_dest=/opt/agbcc
+
+if [ $# -ge 1 ]; then
+    dest="$(realpath "$1")"
 else
-    echo "Usage: install.sh PATH"
+    echo "INFO: Missing parameter, defaulting to installing in $default_dest" 1>&2
+    dest="$default_dest"
 fi
+
+# Check if we can access $dest
+if [ -d "$dest" -a ! -w "$dest" ] || ! install -d "$dest" 2> /dev/null; then
+   echo "ERROR: Can't access directory '$dest'. Are you sure you have sufficient permissions? (hint: use 'sudo ./install.sh')" 1>&2
+   exit 1
+fi
+
+install -Dm755 -t "$dest/bin" agbcc old_agbcc agbcc_arm
+install -Dm644 -t "$dest/lib" libgcc.a libc.a
+install -Dm644 -t "$dest/include" ginclude/*
+cp -R libc/include "$dest/" #drop include, because we don't want include/include
+make -C binutils/build DESTDIR="$dest" install

--- a/install.sh
+++ b/install.sh
@@ -1,17 +1,12 @@
 #!/bin/sh
 set -e
 if [ "$1" != "" ]; then
-    mkdir -p $1/tools/agbcc
-    mkdir -p $1/tools/agbcc/bin
-    mkdir -p $1/tools/agbcc/include
-    mkdir -p $1/tools/agbcc/lib
-    cp agbcc $1/tools/agbcc/bin/
-    cp old_agbcc $1/tools/agbcc/bin/
-    cp agbcc_arm $1/tools/agbcc/bin/
-    cp -R libc/include $1/tools/agbcc/ #drop include, because we don't want include/include
-    cp ginclude/* $1/tools/agbcc/include/
-    cp libgcc.a $1/tools/agbcc/lib/
-    cp libc.a $1/tools/agbcc/lib/
+    dest="$(realpath "$1/tools/agbcc")"
+    install -Dm755 -t "$dest/bin" agbcc old_agbcc agbcc_arm
+    install -Dm644 -t "$dest/lib" libgcc.a libc.a
+    install -Dm644 -t "$dest/include" ginclude/*
+    cp -R libc/include "$dest/" #drop include, because we don't want include/include
+    make -C binutils/build DESTDIR="$dest" install
 else
     echo "Usage: install.sh PATH"
 fi

--- a/libc/Makefile
+++ b/libc/Makefile
@@ -1,25 +1,10 @@
-ifneq (,$(DEVKITARM))
-    ifneq (,$(wildcard $(DEVKITARM)/bin))	    
-        include $(DEVKITARM)/base_tools
-        DKA_EXISTS=1
-    else
-        DKA_EXISTS=0
-    endif
-else
-DKA_EXISTS=0
-endif
-
-ifneq ($(DKA_EXISTS),1)
-PREFIX := arm-none-eabi-
-export AR := $(PREFIX)ar
-export AS := $(PREFIX)as
-endif
-
 SHELL := /bin/bash -o pipefail
 
 ASFLAGS := -mcpu=arm7tdmi
 
-CC1    := ../old_agbcc
+AR := ../binutils/build/binutils/ar
+AS := ../binutils/build/gas/as-new
+CC1 := ../old_agbcc
 CFLAGS := -O2 -fno-builtin
 
 CPPFLAGS := -I ../ginclude -I include -nostdinc -undef \

--- a/libgcc/Makefile
+++ b/libgcc/Makefile
@@ -1,21 +1,6 @@
-ifneq (,$(DEVKITARM))
-    ifneq (,$(wildcard $(DEVKITARM)/bin))	    
-        include $(DEVKITARM)/base_tools
-        DKA_EXISTS=1
-    else
-        DKA_EXISTS=0
-    endif
-else
-DKA_EXISTS=0
-endif
-
-ifneq ($(DKA_EXISTS),1)
-PREFIX := arm-none-eabi-
-export AR := $(PREFIX)ar
-export AS := $(PREFIX)as
-endif
-
-CC1 = ../old_agbcc
+AR := ../binutils/build/binutils/ar
+AS := ../binutils/build/gas/as-new
+CC1 := ../old_agbcc
 
 libgcc.a: libgcc1.a libgcc2.a fp-bit.o dp-bit.o
 	$(AR) -x libgcc1.a;


### PR DESCRIPTION
This was discussed on Discord a while ago, and was prompted by the incompatibility of devkitpro with yet another platform.

I consider the installation of devkitpro to be an unnecessary obstacle, due to the only required component of it being binutils. This is both annoying for the user, and adds unnecessary variability in the users' toolchains, as well as install instructions. A user shouldn't be bothered with figuring out what binutils distribution to use to get their tools.

My hope is that this PR will manage to streamline the installation process and instructions of the gen3 pokemon repositories as well as any other decompilation, and rid them of devkitpro, and other environment-specific makefile code.

In essence, binutils will be compiled alongside agbcc (and libc/libgcc will be compiled with *that*), when running `./build.sh`, and installed when running `./install.sh`.

Right now, due to the way the gen3 repositories are structured, you'll have to run `make TOOLCHAIN="$PWD/tools/agbcc"` to compile the code after installing this version of agbcc. In the long run this will be solved by simplifying the makefiles themselves.

#### Why this is a draft

It works on my machine, haven't bothered testing in all the different environments we support, as this is quite the boring task. I just wanted to push out a "proof of concept", that should be a minimum working set of changes.

#### What else could be done to improve the install process

We've discussed in the discord that installing by default into `/opt/agbcc` (or `/opt/pret`) might be desireable, as this avoids any issues users are having with installing it into the right directory, and allows them to share the same toolchain across repositories. Of course, this should be expanded with an environment variable for the user to supply a custom location, that scripts and makefiles can pick up on.

Additionally, more things could be added to this bundle, such as for example, build-time dependencies for various pret tools (think libpng), or the pret tools themselves.

Personally, I think it should be considered to somehow make this a *full* gcc bundle, with preprocessor and gcc frontend, just an older cc1. This will be significantly harder than the current endeavour, and compiling GCC both takes significantly longer and some more build-time dependencies, but will rid us of the last string of platform-dependency that might differ in behavior: the preprocessor. Alternatively, figure out how to build the preprocessor without the rest of GCC. In either case, this would rid us from having to gather a build of GCC for Mac, just for the preprocessor.

As a last note, in case the bundle grows too big or starts taking too long to compile (or needs too many dependencies), it can always be considered to ship a prebuilt bundle for the most common platforms/environments. Binutils and GCC are both very light on system requirements, and builds of them are usually fairly portable, even to different linux distributions.
