### PR TITLE
Add flag to output standard-compliant .debug_abbrev section

### DIFF
--- a/gcc/dwarf2out.c
+++ b/gcc/dwarf2out.c
@@ -3697,6 +3697,14 @@ output_abbrev_section ()
 
       fprintf (asm_out_file, "\t%s\t0,0\n", ASM_BYTE_OP);
     }
+
+  if (flag_dwarf_bugfix)
+  {
+    /* We need to properly terminate the abbrev table for this
+       compilation unit, as per the standard, and not rely on
+       workarounds in e.g. gdb.  */
+    fprintf (asm_out_file, "\t%s\t0\n", ASM_BYTE_OP);
+  }
 }
 
 /* Output location description stack opcode's operands (if any).  */

--- a/gcc/flags.h
+++ b/gcc/flags.h
@@ -450,3 +450,6 @@ extern enum graph_dump_types graph_dump_format;
 
 /* Nonzero if ASM output should use hex instead of decimal.  */
 extern int flag_hex_asm;
+
+/* Nonzero if dwarf bug should be fixed.  */
+extern int flag_dwarf_bugfix;

--- a/gcc/toplev.c
+++ b/gcc/toplev.c
@@ -585,6 +585,9 @@ int flag_instrument_function_entry_exit = 0;
 /* Use hex instead of decimal in ASM output.  */
 int flag_hex_asm = 0;
 
+/* Output standard-compliant dwarf .debug_abbrev section.  */
+int flag_dwarf_bugfix = 0;
+
 typedef struct
 {
     char *string;
@@ -724,6 +727,8 @@ lang_independent_options f_options[] =
      "Instrument function entry/exit with profiling calls"},
     {"hex-asm", &flag_hex_asm, 1,
      "Use hex instead of decimal in assembly output"},
+    {"dwarf-bugfix", &flag_dwarf_bugfix, 1,
+     "Output standard-compliant dwarf .debug_abbrev section"},
 };
 
 #define NUM_ELEM(a)  (sizeof (a) / sizeof ((a)[0]))


### PR DESCRIPTION
Adds the `-fdwarf-bugfix` flag which adds a 0 byte to the end of the `.debug_abbrev` section.
This allows the DWARF debug information in the generated elf file to be parsed without errors by readelf or Ghidra.

From section **7.5.3 Abbreviation Tables** of [the DWARF 2.0 standard](https://dwarfstd.org/doc/dwarf-2.0.0.pdf):
> The abbreviations for a given compilation unit end with an entry consisting of a 0 byte for the abbreviation code.  