### PR TITLE
(Optional) fix for .debug_line head generation

### DIFF
--- a/gcc/dwarf2out.c
+++ b/gcc/dwarf2out.c
@@ -4323,10 +4323,10 @@ output_line_info ()
   ASM_GENERATE_INTERNAL_LABEL (p1, LN_PROLOG_AS_LABEL, 0);
   ASM_GENERATE_INTERNAL_LABEL (p2, LN_PROLOG_END_LABEL, 0);
 
-  if (flag_legacy_debug_info)
-    ASM_OUTPUT_DWARF_DATA (asm_out_file, size_of_line_info ());
-  else
+  if (flag_fixed_debug_line_info)
     ASM_OUTPUT_DWARF_DELTA (asm_out_file, l2, l1);
+  else
+    ASM_OUTPUT_DWARF_DATA (asm_out_file, size_of_line_info ());
 
   if (flag_debug_asm)
     fprintf (asm_out_file, "\t%s Length of Source Line Info.",
@@ -4334,7 +4334,8 @@ output_line_info ()
 
   fputc ('\n', asm_out_file);
 
-  if (!flag_legacy_debug_info)
+  if (flag_fixed_debug_line_info)
+    /* start of .debug_line */
     ASM_OUTPUT_LABEL(asm_out_file, l1);
 
   ASM_OUTPUT_DWARF_DATA2 (asm_out_file, DWARF_VERSION);
@@ -4343,17 +4344,18 @@ output_line_info ()
 
   fputc ('\n', asm_out_file);
 
-  if (flag_legacy_debug_info)
-    ASM_OUTPUT_DWARF_DATA (asm_out_file, size_of_line_prolog ());
-  else
+  if (flag_fixed_debug_line_info)
     ASM_OUTPUT_DWARF_DELTA (asm_out_file, p2, p1);
+  else
+    ASM_OUTPUT_DWARF_DATA (asm_out_file, size_of_line_prolog ());
 
   if (flag_debug_asm)
     fprintf (asm_out_file, "\t%s Prolog Length", ASM_COMMENT_START);
 
   fputc ('\n', asm_out_file);
 
-  if (!flag_legacy_debug_info)
+  if (flag_fixed_debug_line_info)
+    /* start of .debug_line prologue */
     ASM_OUTPUT_LABEL(asm_out_file, p1);
 
   ASM_OUTPUT_DWARF_DATA1 (asm_out_file, DWARF_LINE_MIN_INSTR_LENGTH);
@@ -4450,7 +4452,8 @@ output_line_info ()
   ASM_OUTPUT_DWARF_DATA1 (asm_out_file, 0);
   fputc ('\n', asm_out_file);
 
-  if (!flag_legacy_debug_info)
+  if (flag_fixed_debug_line_info)
+    /* end of .debug_line prologue */
     ASM_OUTPUT_LABEL (asm_out_file, p2);
 
   /* Set the address register to the first location in the text section */
@@ -4769,8 +4772,8 @@ output_line_info ()
 	}
     }
 
-  if (!flag_legacy_debug_info)
-    /* Output the marker for the end of the line number info.  */
+  if (flag_fixed_debug_line_info)
+    /* end of .debug_line */
     ASM_OUTPUT_LABEL (asm_out_file, l2);
 }
 

--- a/gcc/dwarf2out.c
+++ b/gcc/dwarf2out.c
@@ -232,6 +232,10 @@ static unsigned reg_number		(rtx);
 #define FDE_AFTER_SIZE_LABEL	"LSFDE"
 #define FDE_END_LABEL		"LEFDE"
 #define FDE_LENGTH_LABEL	"LLFDE"
+#define LINE_NUMBER_BEGIN_LABEL	"LSLT"
+#define LINE_NUMBER_END_LABEL	"LELT"
+#define LN_PROLOG_AS_LABEL	"LASLTP"
+#define LN_PROLOG_END_LABEL	"LELTP"
 
 /* Definitions of defaults for various types of primitive assembly language
    output operations.  These may be overridden from within the tm.h file,
@@ -4301,6 +4305,7 @@ output_aranges ()
 static void
 output_line_info ()
 {
+  char l1[20], l2[20], p1[20], p2[20];
   char line_label[MAX_ARTIFICIAL_LABEL_BYTES];
   char prev_line_label[MAX_ARTIFICIAL_LABEL_BYTES];
   register unsigned opc;
@@ -4313,22 +4318,44 @@ output_line_info ()
   register unsigned long current_file;
   register unsigned long function;
 
-  ASM_OUTPUT_DWARF_DATA (asm_out_file, size_of_line_info ());
+  ASM_GENERATE_INTERNAL_LABEL (l1, LINE_NUMBER_BEGIN_LABEL, 0);
+  ASM_GENERATE_INTERNAL_LABEL (l2, LINE_NUMBER_END_LABEL, 0);
+  ASM_GENERATE_INTERNAL_LABEL (p1, LN_PROLOG_AS_LABEL, 0);
+  ASM_GENERATE_INTERNAL_LABEL (p2, LN_PROLOG_END_LABEL, 0);
+
+  if (flag_legacy_debug_info)
+    ASM_OUTPUT_DWARF_DATA (asm_out_file, size_of_line_info ());
+  else
+    ASM_OUTPUT_DWARF_DELTA (asm_out_file, l2, l1);
+
   if (flag_debug_asm)
     fprintf (asm_out_file, "\t%s Length of Source Line Info.",
 	     ASM_COMMENT_START);
 
   fputc ('\n', asm_out_file);
+
+  if (!flag_legacy_debug_info)
+    ASM_OUTPUT_LABEL(asm_out_file, l1);
+
   ASM_OUTPUT_DWARF_DATA2 (asm_out_file, DWARF_VERSION);
   if (flag_debug_asm)
     fprintf (asm_out_file, "\t%s DWARF Version", ASM_COMMENT_START);
 
   fputc ('\n', asm_out_file);
-  ASM_OUTPUT_DWARF_DATA (asm_out_file, size_of_line_prolog ());
+
+  if (flag_legacy_debug_info)
+    ASM_OUTPUT_DWARF_DATA (asm_out_file, size_of_line_prolog ());
+  else
+    ASM_OUTPUT_DWARF_DELTA (asm_out_file, p2, p1);
+
   if (flag_debug_asm)
     fprintf (asm_out_file, "\t%s Prolog Length", ASM_COMMENT_START);
 
   fputc ('\n', asm_out_file);
+
+  if (!flag_legacy_debug_info)
+    ASM_OUTPUT_LABEL(asm_out_file, p1);
+
   ASM_OUTPUT_DWARF_DATA1 (asm_out_file, DWARF_LINE_MIN_INSTR_LENGTH);
   if (flag_debug_asm)
     fprintf (asm_out_file, "\t%s Minimum Instruction Length",
@@ -4422,6 +4449,9 @@ output_line_info ()
   /* Terminate the file name table */
   ASM_OUTPUT_DWARF_DATA1 (asm_out_file, 0);
   fputc ('\n', asm_out_file);
+
+  if (!flag_legacy_debug_info)
+    ASM_OUTPUT_LABEL (asm_out_file, p2);
 
   /* Set the address register to the first location in the text section */
   ASM_OUTPUT_DWARF_DATA1 (asm_out_file, 0);
@@ -4738,6 +4768,10 @@ output_line_info ()
 	  fputc ('\n', asm_out_file);
 	}
     }
+
+  if (!flag_legacy_debug_info)
+    /* Output the marker for the end of the line number info.  */
+    ASM_OUTPUT_LABEL (asm_out_file, l2);
 }
 
 /* Given a pointer to a BLOCK node return non-zero if (and only if) the node

--- a/gcc/flags.h
+++ b/gcc/flags.h
@@ -451,6 +451,6 @@ extern enum graph_dump_types graph_dump_format;
 /* Nonzero if ASM output should use hex instead of decimal.  */
 extern int flag_hex_asm;
 
-/* Nonzero if generated DWARF debug info should match (buggy) original
-   GCC 2.95.x behavior. */
-extern int flag_legacy_debug_info;
+/* Nonzero if generated DWARF debug info should be corrected rather than
+   match the original (buggy) GCC 2.95.x output. */
+extern int flag_fixed_debug_line_info;

--- a/gcc/flags.h
+++ b/gcc/flags.h
@@ -450,3 +450,7 @@ extern enum graph_dump_types graph_dump_format;
 
 /* Nonzero if ASM output should use hex instead of decimal.  */
 extern int flag_hex_asm;
+
+/* Nonzero if generated DWARF debug info should match (buggy) original
+   GCC 2.95.x behavior. */
+extern int flag_legacy_debug_info;

--- a/gcc/toplev.c
+++ b/gcc/toplev.c
@@ -585,6 +585,9 @@ int flag_instrument_function_entry_exit = 0;
 /* Use hex instead of decimal in ASM output.  */
 int flag_hex_asm = 0;
 
+/* Use old (buggy) DWARF line info generator. */
+int flag_legacy_debug_info = 0;
+
 typedef struct
 {
     char *string;
@@ -724,6 +727,8 @@ lang_independent_options f_options[] =
      "Instrument function entry/exit with profiling calls"},
     {"hex-asm", &flag_hex_asm, 1,
      "Use hex instead of decimal in assembly output"},
+    {"legacy-debug-line-info", &flag_legacy_debug_info, 1,
+     "Generate old (buggy) DWARF line info"},
 };
 
 #define NUM_ELEM(a)  (sizeof (a) / sizeof ((a)[0]))

--- a/gcc/toplev.c
+++ b/gcc/toplev.c
@@ -585,7 +585,7 @@ int flag_instrument_function_entry_exit = 0;
 /* Use hex instead of decimal in ASM output.  */
 int flag_hex_asm = 0;
 
-/* Use old (buggy) DWARF line info generator. */
+/* Fix buggy DWARF line info generation.  */
 int flag_fixed_debug_line_info = 0;
 
 typedef struct

--- a/gcc/toplev.c
+++ b/gcc/toplev.c
@@ -586,7 +586,7 @@ int flag_instrument_function_entry_exit = 0;
 int flag_hex_asm = 0;
 
 /* Use old (buggy) DWARF line info generator. */
-int flag_legacy_debug_info = 0;
+int flag_fixed_debug_line_info = 0;
 
 typedef struct
 {
@@ -727,8 +727,8 @@ lang_independent_options f_options[] =
      "Instrument function entry/exit with profiling calls"},
     {"hex-asm", &flag_hex_asm, 1,
      "Use hex instead of decimal in assembly output"},
-    {"legacy-debug-line-info", &flag_legacy_debug_info, 1,
-     "Generate old (buggy) DWARF line info"},
+    {"fix-debug-line", &flag_fixed_debug_line_info, 1,
+     "Generate fixed DWARF line info"},
 };
 
 #define NUM_ELEM(a)  (sizeof (a) / sizeof ((a)[0]))


### PR DESCRIPTION
Sometimes when using tools for reading line number information out of objects generated by agbcc, you'd get the follwing error:

    DWARF error: mangled line number section

This is presumably caused by the function `size_of_line_info` (in gcc/dwarf2out.c) sometimes mispredicting the actual size of the rest of the `.debug_line` section. This was fixed here by generating label deltas instead of using that function (as is done in more recent versions of GCC).

The optional `-ffix-debug-line` flag enables this new behavior.

Note: that fix probably needs to eventually be ported to agbcc_arm as well as any fork featuring agbcp.

---

I'm only now seeing that there's another debug info related PR in (#49) featuring the addition of a new flag. Perhaps it would be interesting to merge the flags into an unified one that either updates/fixes debug info generation or restores the old buggy one.