### PR TITLE
Refactor all uses of GEN_FCN to use locals

### DIFF
--- a/gcc/expmed.c
+++ b/gcc/expmed.c
@@ -345,8 +345,11 @@ store_bit_field (str_rtx, bitsize, bitnum, fieldmode, value, align, total_size)
 		abort ();
 	    }
 
-	  emit_insn (GEN_FCN (icode)
-		   (gen_rtx_SUBREG (fieldmode, op0, offset), value));
+	    {
+	      rtx (*gen_insn)(rtx, rtx) = GEN_FCN (icode);
+	      emit_insn (gen_insn
+		  (gen_rtx_SUBREG (fieldmode, op0, offset), value));
+	    }
 	}
       return value;
     }
@@ -3818,7 +3821,10 @@ emit_store_flag (target, code, op0, op1, mode, unsignedp, normalizep)
 	  || ! (*insn_operand_predicate[(int) icode][0]) (subtarget, compare_mode))
 	subtarget = gen_reg_rtx (compare_mode);
 
-      pattern = GEN_FCN (icode) (subtarget);
+	{
+	  rtx (*gen_insn)(rtx) = GEN_FCN (icode);
+	  pattern = gen_insn (subtarget);
+	}
       if (pattern)
 	{
 	  emit_insn (pattern);

--- a/gcc/expr.c
+++ b/gcc/expr.c
@@ -123,7 +123,7 @@ static rtx enqueue_insn         (rtx, rtx);
 static int queued_subexp_p      (rtx);
 static void init_queue          (void);
 static int move_by_pieces_ninsns (unsigned int, int);
-static void move_by_pieces_1    (rtx (*)(rtx, ...), enum machine_mode,
+static void move_by_pieces_1    (rtx (*)(rtx, rtx), enum machine_mode,
                                  struct move_by_pieces *);
 static void clear_by_pieces     (rtx, int, int);
 static void clear_by_pieces_1   (rtx (*)(rtx, rtx), enum machine_mode,
@@ -1093,7 +1093,7 @@ move_by_pieces_ninsns(unsigned int l, int align)
    to make a move insn for that mode.  DATA has all the other info.  */
 
 static void
-move_by_pieces_1(rtx (*genfun) (rtx, ...), enum machine_mode mode, struct move_by_pieces *data)
+move_by_pieces_1(rtx (*genfun) (rtx, rtx), enum machine_mode mode, struct move_by_pieces *data)
 {
     register int size = GET_MODE_SIZE(mode);
     register rtx to1, from1;

--- a/gcc/expr.c
+++ b/gcc/expr.c
@@ -126,7 +126,7 @@ static int move_by_pieces_ninsns (unsigned int, int);
 static void move_by_pieces_1    (rtx (*)(rtx, ...), enum machine_mode,
                                  struct move_by_pieces *);
 static void clear_by_pieces     (rtx, int, int);
-static void clear_by_pieces_1   (rtx (*)(rtx, ...), enum machine_mode,
+static void clear_by_pieces_1   (rtx (*)(rtx, rtx), enum machine_mode,
                                  struct clear_by_pieces *);
 static int is_zeros_p           (tree);
 static int mostly_zeros_p       (tree);
@@ -1212,7 +1212,11 @@ emit_block_move(rtx x, rtx y, rtx size, int align)
                     && !(*insn_operand_predicate[(int) code][2])(op2, mode))
                     op2 = copy_to_mode_reg(mode, op2);
 
-                pat = GEN_FCN((int) code) (x, y, op2, opalign);
+                {
+                    rtx (*gen_insn)(rtx, rtx, rtx, rtx) = GEN_FCN ((int) code);
+                    pat = gen_insn (x, y, op2, opalign);
+                }
+
                 if (pat)
                 {
                     emit_insn(pat);
@@ -1737,7 +1741,7 @@ clear_by_pieces(rtx to, int len, int align)
    to make a move insn for that mode.  DATA has all the other info.  */
 
 static void
-clear_by_pieces_1(rtx (*genfun) (rtx, ...), enum machine_mode mode, struct clear_by_pieces *data)
+clear_by_pieces_1(rtx (*genfun) (rtx, rtx), enum machine_mode mode, struct clear_by_pieces *data)
 {
     register int size = GET_MODE_SIZE(mode);
     register rtx to1;
@@ -1827,7 +1831,11 @@ clear_storage(rtx object, rtx size, int align)
                                                                      mode))
                         op1 = copy_to_mode_reg(mode, op1);
 
-                    pat = GEN_FCN((int) code) (object, op1, opalign);
+                    {
+                        rtx (*gen_insn)(rtx, rtx, rtx) = GEN_FCN ((int) code);
+                        pat = gen_insn (object, op1, opalign);
+                    }
+
                     if (pat)
                     {
                         emit_insn(pat);
@@ -1983,8 +1991,11 @@ emit_move_insn_1(rtx x, rtx y)
     /* END CYGNUS LOCAL */
 
     if (mov_optab->handlers[(int) mode].insn_code != CODE_FOR_nothing)
+    {
+        rtx (*gen_insn)(rtx, rtx) = GEN_FCN (mov_optab->handlers[(int) mode].insn_code);
         return
-            emit_insn(GEN_FCN(mov_optab->handlers[(int) mode].insn_code) (x, y));
+            emit_insn(gen_insn (x, y));
+    }
 
     /* Expand complex moves by moving real part and imag part, if possible.  */
     else if ((class == MODE_COMPLEX_FLOAT || class == MODE_COMPLEX_INT)
@@ -1998,6 +2009,7 @@ emit_move_insn_1(rtx x, rtx y)
     {
         /* Don't split destination if it is a stack push.  */
         int stack = push_operand(x, GET_MODE(x));
+        rtx (*gen_insn)(rtx, rtx) = GEN_FCN (mov_optab->handlers[(int) submode].insn_code);
 
         /* If this is a stack, push the highpart first, so it
            will be in the argument order.
@@ -2008,10 +2020,10 @@ emit_move_insn_1(rtx x, rtx y)
         {
             /* Note that the real part always precedes the imag part in memory
                regardless of machine's endianness.  */
-            emit_insn(GEN_FCN(mov_optab->handlers[(int) submode].insn_code)
+            emit_insn(gen_insn
                           (gen_rtx_MEM(submode, (XEXP(x, 0))),
                           gen_imagpart(submode, y)));
-            emit_insn(GEN_FCN(mov_optab->handlers[(int) submode].insn_code)
+            emit_insn(gen_insn
                           (gen_rtx_MEM(submode, (XEXP(x, 0))),
                           gen_realpart(submode, y)));
         }
@@ -2026,9 +2038,9 @@ emit_move_insn_1(rtx x, rtx y)
                 emit_insn(gen_rtx_CLOBBER(VOIDmode, x));
             }
 
-            emit_insn(GEN_FCN(mov_optab->handlers[(int) submode].insn_code)
+            emit_insn(gen_insn
                           (gen_realpart(submode, x), gen_realpart(submode, y)));
-            emit_insn(GEN_FCN(mov_optab->handlers[(int) submode].insn_code)
+            emit_insn(gen_insn
                           (gen_imagpart(submode, x), gen_imagpart(submode, y)));
         }
 
@@ -2313,13 +2325,14 @@ int reg_parm_stack_space;
                         rtx op2 = convert_to_mode(mode, size, 1);
                         rtx last = get_last_insn();
                         rtx pat;
+                        rtx (*gen_insn)(rtx, rtx, rtx, rtx) = GEN_FCN ((int) code);
 
                         if (insn_operand_predicate[(int) code][2] != 0
                             && !((*insn_operand_predicate[(int) code][2])
                                      (op2, mode)))
                             op2 = copy_to_mode_reg(mode, op2);
 
-                        pat = GEN_FCN((int) code) (target, xinner,
+                        pat = gen_insn (target, xinner,
                                                    op2, opalign);
                         if (pat)
                         {
@@ -8838,13 +8851,17 @@ expand_increment(register tree exp, int post, int ignore)
             && (*insn_operand_predicate[icode][0])(op0, mode)
             && (*insn_operand_predicate[icode][1])(op0, mode))
         {
+            rtx (*gen_insn)(rtx, rtx, rtx) = GEN_FCN (icode);
+
             if (!(*insn_operand_predicate[icode][2])(op1, mode))
                 op1 = force_reg(mode, op1);
 
-            return enqueue_insn(op0, GEN_FCN (icode) (op0, op0, op1));
+            return enqueue_insn(op0, gen_insn (op0, op0, op1));
         }
         if (icode != (int) CODE_FOR_nothing && GET_CODE(op0) == MEM)
         {
+            rtx (*gen_insn)(rtx, rtx, rtx) = GEN_FCN (icode);
+
             rtx addr = (general_operand(XEXP(op0, 0), mode)
                         ? force_reg(Pmode, XEXP(op0, 0))
                         : copy_to_reg(XEXP(op0, 0)));
@@ -8858,7 +8875,7 @@ expand_increment(register tree exp, int post, int ignore)
             /* The increment queue is LIFO, thus we have to `queue'
                the instructions in reverse order.  */
             enqueue_insn(op0, gen_move_insn(op0, temp));
-            result = enqueue_insn(temp, GEN_FCN (icode) (temp, temp, op1));
+            result = enqueue_insn(temp, gen_insn (temp, temp, op1));
             return result;
         }
     }

--- a/gcc/loop.c
+++ b/gcc/loop.c
@@ -7489,9 +7489,12 @@ check_dbra_loop (loop_end, insn_count, loop_start, loop_info)
 		    return 0;
 		  start_value
 		    = gen_rtx_PLUS (mode, comparison_value, offset);
-		  emit_insn_before ((GEN_FCN (icode)
+		    {
+			  rtx (*gen_insn)(rtx, rtx, rtx) = GEN_FCN (icode);
+			  emit_insn_before ((gen_insn
 				     (reg, comparison_value, offset)),
 				    loop_start);
+			}
 		  if (GET_CODE (comparison) == LE)
 		    final_value = gen_rtx_PLUS (mode, comparison_value,
 						GEN_INT (add_val));
@@ -7509,9 +7512,12 @@ check_dbra_loop (loop_end, insn_count, loop_start, loop_info)
 		    return 0;
 		  start_value
 		    = gen_rtx_MINUS (mode, comparison_value, initial_value);
-		  emit_insn_before ((GEN_FCN (icode)
-				     (reg, comparison_value, initial_value)),
-				    loop_start);
+		    {
+			  rtx (*gen_insn)(rtx, rtx, rtx) = GEN_FCN (icode);
+			  emit_insn_before ((gen_insn
+				(reg, comparison_value, initial_value)),
+				loop_start);
+			}
 		}
 	      else
 		/* We could handle the other cases too, but it'll be

--- a/gcc/optabs.c
+++ b/gcc/optabs.c
@@ -499,7 +499,10 @@ expand_binop (mode, binoptab, op0, op1, target, unsignedp, methods)
       if (! (*insn_operand_predicate[icode][0]) (temp, mode))
 	temp = gen_reg_rtx (mode);
 
-      pat = GEN_FCN (icode) (temp, xop0, xop1);
+        {
+          rtx (*gen_insn)(rtx, rtx, rtx) = (GEN_FCN (icode));
+          pat = gen_insn(temp, xop0, xop1);
+        }
       if (pat)
 	{
 	  /* If PAT is a multi-insn sequence, try to add an appropriate
@@ -1781,7 +1784,10 @@ expand_twoval_binop (binoptab, op0, op1, targ0, targ1, unsignedp)
 	  || ! (*insn_operand_predicate[icode][3]) (targ1, mode))
 	abort ();
 	
-      pat = GEN_FCN (icode) (targ0, xop0, xop1, targ1);
+        {
+          rtx (*gen_insn)(rtx, rtx, rtx, rtx) = (GEN_FCN (icode));
+          pat = gen_insn(targ0, xop0, xop1, targ1);
+        }
       if (pat)
 	{
 	  emit_insn (pat);
@@ -1885,7 +1891,10 @@ expand_unop (mode, unoptab, op0, target, unsignedp)
       if (! (*insn_operand_predicate[icode][0]) (temp, mode))
 	temp = gen_reg_rtx (mode);
 
-      pat = GEN_FCN (icode) (temp, xop0);
+    {
+      rtx (*gen_insn)(rtx, rtx) = (GEN_FCN (icode));
+      pat = gen_insn(temp, xop0);
+    }
       if (pat)
 	{
 	  if (GET_CODE (pat) == SEQUENCE
@@ -2258,7 +2267,10 @@ expand_complex_abs (mode, op0, target, unsignedp)
       if (! (*insn_operand_predicate[icode][0]) (temp, submode))
 	temp = gen_reg_rtx (submode);
 
-      pat = GEN_FCN (icode) (temp, xop0);
+        {
+          rtx (*gen_insn)(rtx, rtx) = (GEN_FCN (icode));
+          pat = gen_insn(temp, xop0);
+        }
       if (pat)
 	{
 	  if (GET_CODE (pat) == SEQUENCE
@@ -2424,7 +2436,10 @@ emit_unop_insn (icode, target, op0, code)
       || (flag_force_mem && GET_CODE (temp) == MEM))
     temp = gen_reg_rtx (GET_MODE (temp));
 
-  pat = GEN_FCN (icode) (temp, op0);
+    {
+      rtx (*gen_insn)(rtx, rtx) = (GEN_FCN (icode));
+      pat = gen_insn(temp, op0);
+    }
 
   if (GET_CODE (pat) == SEQUENCE && code != UNKNOWN)
     add_equal_note (pat, temp, code, op0, NULL_RTX);
@@ -2842,7 +2857,10 @@ emit_cmp_insn (x, y, comparison, size, mode, unsignedp, align)
 	  (x, insn_operand_mode[icode][0]))
 	x = copy_to_mode_reg (insn_operand_mode[icode][0], x);
 
-      emit_insn (GEN_FCN (icode) (x));
+      {
+        rtx (*gen_insn)(rtx) = (GEN_FCN (icode));
+        emit_insn (gen_insn(x));
+      }
       return;
     }
 
@@ -2865,7 +2883,11 @@ emit_cmp_insn (x, y, comparison, size, mode, unsignedp, align)
 	  (y, insn_operand_mode[icode][1]))
 	y = copy_to_mode_reg (insn_operand_mode[icode][1], y);
 
-      emit_insn (GEN_FCN (icode) (x, y));
+      {
+        rtx (*gen_insn)(rtx, rtx) = (GEN_FCN (icode));
+        emit_insn (gen_insn(x, y));
+      }
+
       return;
     }
 
@@ -3221,7 +3243,10 @@ emit_conditional_move (target, code, op0, op1, cmode, op2, op3, mode,
     /* This shouldn't happen.  */
     abort ();
   
-  insn = GEN_FCN (icode) (subtarget, comparison, op2, op3);
+    {
+      rtx (*gen_insn)(rtx, rtx, rtx, rtx) = (GEN_FCN (icode));
+      insn = gen_insn(subtarget, comparison, op2, op3);
+    }
 
   /* If that failed, then give up.  */
   if (insn == 0)
@@ -3275,7 +3300,10 @@ gen_add2_insn (x, y)
       || ! (*insn_operand_predicate[icode][2]) (y, insn_operand_mode[icode][2]))
     abort ();
 
-  return (GEN_FCN (icode) (x, x, y));
+  {
+    rtx (*gen_insn)(rtx, rtx, rtx) = (GEN_FCN (icode));
+    return gen_insn(x, x, y);
+  }
 }
 
 int
@@ -3298,7 +3326,10 @@ gen_sub2_insn (x, y)
       || ! (*insn_operand_predicate[icode][2]) (y, insn_operand_mode[icode][2]))
     abort ();
 
-  return (GEN_FCN (icode) (x, x, y));
+  {
+    rtx (*gen_insn)(rtx, rtx, rtx) = (GEN_FCN (icode));
+    return gen_insn(x, x, y);
+  }
 }
 
 int
@@ -3379,7 +3410,10 @@ gen_move_insn (x, y)
 	}
 	  
       insn_code = mov_optab->handlers[(int) tmode].insn_code;
-      return (GEN_FCN (insn_code) (x, y));
+      {
+        rtx (*gen_insn)(rtx, rtx) = (GEN_FCN (insn_code));
+        return gen_insn(x, y);
+      }
     }
 
   start_sequence ();
@@ -3410,7 +3444,8 @@ gen_extend_insn (x, y, mto, mfrom, unsignedp)
      enum machine_mode mto, mfrom;
      int unsignedp;
 {
-  return (GEN_FCN (extendtab[(int) mto][(int) mfrom][unsignedp]) (x, y));
+  rtx (*gen_insn)(rtx, rtx) = (GEN_FCN (extendtab[(int) mto][(int) mfrom][unsignedp]));
+  return (gen_insn (x, y));
 }
 
 /* can_fix_p and can_float_p say whether the target machine
@@ -4374,7 +4409,8 @@ gen_cond_trap (code, op1, op2, tcode)
       && cmp_optab->handlers[(int) mode].insn_code != CODE_FOR_nothing)
     {
       rtx insn;
-      emit_insn (GEN_FCN (cmp_optab->handlers[(int) mode].insn_code) (op1, op2));
+      rtx (*gen_insn)(rtx, rtx) = GEN_FCN (cmp_optab->handlers[(int) mode].insn_code);
+      emit_insn (gen_insn (op1, op2));
       PUT_CODE (trap_rtx, code);
       insn = gen_conditional_trap (trap_rtx, tcode);
       if (insn)

--- a/gcc/regmove.c
+++ b/gcc/regmove.c
@@ -110,7 +110,10 @@ gen_add3_insn (r0, r1, c)
 
   if ((*insn_operand_predicate[icode][1])(r1, insn_operand_mode[icode][1])
       && (*insn_operand_predicate[icode][2])(c, insn_operand_mode[icode][2]))
-    return (GEN_FCN (icode) (r0, r1, c));
+    {
+      rtx (*gen_insn)(rtx, rtx, rtx) = GEN_FCN (icode);
+      return (gen_insn (r0, r1, c));
+    }
 
   mcode = (int) mov_optab->handlers[(int) GET_MODE (r0)].insn_code;
   if (REGNO (r0) == REGNO (r1)
@@ -121,8 +124,14 @@ gen_add3_insn (r0, r1, c)
     return NULL_RTX;
 
   start_sequence ();
-  emit_insn (GEN_FCN (mcode) (r0, c));
-  emit_insn (GEN_FCN (icode) (r0, r0, r1));
+    {
+      rtx (*gen_insn)(rtx, rtx) = GEN_FCN (mcode);
+      emit_insn (gen_insn (r0, c));
+    }
+    {
+      rtx (*gen_insn)(rtx, rtx, rtx) = GEN_FCN (icode);
+      emit_insn (gen_insn (r0, r0, r1));
+    }
   s = gen_sequence ();
   end_sequence ();
   return s;
@@ -1571,7 +1580,10 @@ optimize_related_values (nregs, regmove_dump_file)
 	  || ! (*insn_operand_predicate[icode][1]) (reg, mode)
 	  || ! (*insn_operand_predicate[icode][2]) (const1_rtx, mode))
 	continue;
-      add = GEN_FCN (icode) (reg, reg, const1_rtx);
+        {
+          rtx (*gen_insn)(rtx, rtx, rtx) = GEN_FCN (icode);
+          add = gen_insn (reg, reg, const1_rtx);
+        }
       if (GET_CODE (add) == SEQUENCE)
 	continue;
       add = make_insn_raw (add);
@@ -3555,7 +3567,10 @@ regmove_profitable_p ()
 	      || ! (*insn_operand_predicate[icode][1]) (reg1, VOIDmode)
 	      || ! (*insn_operand_predicate[icode][2]) (reg2, VOIDmode))
 	    break;
-	  pat = GEN_FCN (icode) (reg0, reg1, reg2);
+    {
+      rtx (*gen_insn)(rtx, rtx, rtx) = GEN_FCN (icode);
+      pat = gen_insn (reg0, reg1, reg2);
+    }
 	  if (! pat)
 	    continue;
 	  if (GET_CODE (pat) == SEQUENCE)

--- a/gcc/reload1.c
+++ b/gcc/reload1.c
@@ -6586,7 +6586,8 @@ emit_reload_insns (chain)
 		    {
 		      if (icode != CODE_FOR_nothing)
 			{
-			  emit_insn (GEN_FCN (icode) (reloadreg, real_oldequiv,
+			  rtx (*gen_insn)(rtx, rtx, rtx) = GEN_FCN (icode);
+			  emit_insn (gen_insn (reloadreg, real_oldequiv,
 						      second_reload_reg));
 			  special = 1;
 			}
@@ -6599,10 +6600,11 @@ emit_reload_insns (chain)
 
 			  if (tertiary_icode != CODE_FOR_nothing)
 			    {
+				  rtx (*gen_insn)(rtx, rtx, rtx) = GEN_FCN (tertiary_icode);
 			      rtx third_reload_reg
 			        = reload_reg_rtx[reload_secondary_in_reload[secondary_reload]];
 
-			      emit_insn ((GEN_FCN (tertiary_icode)
+			      emit_insn ((gen_insn
 					  (second_reload_reg, real_oldequiv,
 					   third_reload_reg)));
 			    }
@@ -6864,8 +6866,11 @@ emit_reload_insns (chain)
 
 			  gen_reload (reloadreg, second_reloadreg,
 				      reload_opnum[j], reload_when_needed[j]);
-			  emit_insn ((GEN_FCN (tertiary_icode)
-				      (real_old, reloadreg, third_reloadreg)));
+			    {
+			      rtx (*gen_insn)(rtx, rtx, rtx) = GEN_FCN (tertiary_icode);
+			      emit_insn ((gen_insn
+					(real_old, reloadreg, third_reloadreg)));
+			    }
 			  special = 1;
 			}
 

--- a/gcc_arm/expmed.c
+++ b/gcc_arm/expmed.c
@@ -363,8 +363,11 @@ store_bit_field (str_rtx, bitsize, bitnum, fieldmode, value, align, total_size)
 		abort ();
 	    }
 
-	  emit_insn (GEN_FCN (icode)
-		   (gen_rtx_SUBREG (fieldmode, op0, offset), value));
+	    {
+	      rtx (*gen_insn)(rtx, rtx) = GEN_FCN (icode);
+	      emit_insn (gen_insn
+		  (gen_rtx_SUBREG (fieldmode, op0, offset), value));
+	    }
 	}
       return value;
     }
@@ -4226,7 +4229,10 @@ emit_store_flag (target, code, op0, op1, mode, unsignedp, normalizep)
 	  || ! (*insn_operand_predicate[(int) icode][0]) (subtarget, compare_mode))
 	subtarget = gen_reg_rtx (compare_mode);
 
-      pattern = GEN_FCN (icode) (subtarget);
+	{
+	  rtx (*gen_insn)(rtx) = GEN_FCN (icode);
+	  pattern = gen_insn (subtarget);
+	}
       if (pattern)
 	{
 	  emit_insn (pattern);

--- a/gcc_arm/expr.c
+++ b/gcc_arm/expr.c
@@ -156,7 +156,7 @@ static rtx enqueue_insn		PROTO((rtx, rtx));
 static int queued_subexp_p	PROTO((rtx));
 static void init_queue		PROTO((void));
 static int move_by_pieces_ninsns PROTO((unsigned int, int));
-static void move_by_pieces_1	PROTO((rtx (*) (rtx, ...), enum machine_mode,
+static void move_by_pieces_1	PROTO((rtx (*) (rtx, rtx), enum machine_mode,
 				       struct move_by_pieces *));
 static void clear_by_pieces	PROTO((rtx, int, int));
 static void clear_by_pieces_1	PROTO((rtx (*) (rtx, rtx), enum machine_mode,
@@ -1589,7 +1589,7 @@ move_by_pieces_ninsns (l, align)
 
 static void
 move_by_pieces_1 (genfun, mode, data)
-     rtx (*genfun) PROTO ((rtx, ...));
+     rtx (*genfun) PROTO ((rtx, rtx));
      enum machine_mode mode;
      struct move_by_pieces *data;
 {

--- a/gcc_arm/expr.c
+++ b/gcc_arm/expr.c
@@ -159,7 +159,7 @@ static int move_by_pieces_ninsns PROTO((unsigned int, int));
 static void move_by_pieces_1	PROTO((rtx (*) (rtx, ...), enum machine_mode,
 				       struct move_by_pieces *));
 static void clear_by_pieces	PROTO((rtx, int, int));
-static void clear_by_pieces_1	PROTO((rtx (*) (rtx, ...), enum machine_mode,
+static void clear_by_pieces_1	PROTO((rtx (*) (rtx, rtx), enum machine_mode,
 				       struct clear_by_pieces *));
 static int is_zeros_p		PROTO((tree));
 static int mostly_zeros_p	PROTO((tree));
@@ -1716,7 +1716,10 @@ emit_block_move (x, y, size, align)
 		  && ! (*insn_operand_predicate[(int) code][2]) (op2, mode))
 		op2 = copy_to_mode_reg (mode, op2);
 
-	      pat = GEN_FCN ((int) code) (x, y, op2, opalign);
+		{
+		  rtx (*gen_insn)(rtx, rtx, rtx, rtx) = GEN_FCN ((int) code);
+		  pat = gen_insn (x, y, op2, opalign);
+		}
 	      if (pat)
 		{
 		  emit_insn (pat);
@@ -2352,7 +2355,7 @@ clear_by_pieces (to, len, align)
 
 static void
 clear_by_pieces_1 (genfun, mode, data)
-     rtx (*genfun) PROTO ((rtx, ...));
+     rtx (*genfun) PROTO ((rtx, rtx));
      enum machine_mode mode;
      struct clear_by_pieces *data;
 {
@@ -2450,7 +2453,10 @@ clear_storage (object, size, align)
 								     mode))
 		    op1 = copy_to_mode_reg (mode, op1);
 
-		  pat = GEN_FCN ((int) code) (object, op1, opalign);
+		    {
+		      rtx (*gen_insn)(rtx, rtx, rtx) = GEN_FCN ((int) code);
+		      pat = gen_insn (object, op1, opalign);
+		    }
 		  if (pat)
 		    {
 		      emit_insn (pat);
@@ -2618,9 +2624,12 @@ emit_move_insn_1 (x, y)
   /* END CYGNUS LOCAL */
 
   if (mov_optab->handlers[(int) mode].insn_code != CODE_FOR_nothing)
-    return
-      emit_insn (GEN_FCN (mov_optab->handlers[(int) mode].insn_code) (x, y));
-
+    {
+      rtx (*gen_insn)(rtx, rtx) = GEN_FCN (mov_optab->handlers[(int) mode].insn_code);
+      return
+        emit_insn (gen_insn (x, y));
+    }
+    
   /* Expand complex moves by moving real part and imag part, if possible.  */
   else if ((class == MODE_COMPLEX_FLOAT || class == MODE_COMPLEX_INT)
 	   && BLKmode != (submode = mode_for_size ((GET_MODE_UNIT_SIZE (mode)
@@ -2633,6 +2642,7 @@ emit_move_insn_1 (x, y)
     {
       /* Don't split destination if it is a stack push.  */
       int stack = push_operand (x, GET_MODE (x));
+      rtx (*gen_insn)(rtx, rtx) = GEN_FCN (mov_optab->handlers[(int) submode].insn_code);
 
       /* If this is a stack, push the highpart first, so it
 	 will be in the argument order.
@@ -2644,17 +2654,17 @@ emit_move_insn_1 (x, y)
 	  /* Note that the real part always precedes the imag part in memory
 	     regardless of machine's endianness.  */
 #ifdef STACK_GROWS_DOWNWARD
-	  emit_insn (GEN_FCN (mov_optab->handlers[(int) submode].insn_code)
+	  emit_insn (gen_insn
 		     (gen_rtx_MEM (submode, (XEXP (x, 0))),
 		      gen_imagpart (submode, y)));
-	  emit_insn (GEN_FCN (mov_optab->handlers[(int) submode].insn_code)
+	  emit_insn (gen_insn
 		     (gen_rtx_MEM (submode, (XEXP (x, 0))),
 		      gen_realpart (submode, y)));
 #else
-	  emit_insn (GEN_FCN (mov_optab->handlers[(int) submode].insn_code)
+	  emit_insn (gen_insn
 		     (gen_rtx_MEM (submode, (XEXP (x, 0))),
 		      gen_realpart (submode, y)));
-	  emit_insn (GEN_FCN (mov_optab->handlers[(int) submode].insn_code)
+	  emit_insn (gen_insn
 		     (gen_rtx_MEM (submode, (XEXP (x, 0))),
 		      gen_imagpart (submode, y)));
 #endif
@@ -2670,9 +2680,9 @@ emit_move_insn_1 (x, y)
 	      emit_insn (gen_rtx_CLOBBER (VOIDmode, x));
 	    }
 
-	  emit_insn (GEN_FCN (mov_optab->handlers[(int) submode].insn_code)
+	  emit_insn (gen_insn
 		     (gen_realpart (submode, x), gen_realpart (submode, y)));
-	  emit_insn (GEN_FCN (mov_optab->handlers[(int) submode].insn_code)
+	  emit_insn (gen_insn
 		     (gen_imagpart (submode, x), gen_imagpart (submode, y)));
 	}
 
@@ -3053,13 +3063,14 @@ emit_push_insn (x, mode, type, size, align, partial, reg, extra,
 		      rtx op2 = convert_to_mode (mode, size, 1);
 		      rtx last = get_last_insn ();
 		      rtx pat;
+		      rtx (*gen_insn)(rtx, rtx, rtx, rtx) = GEN_FCN ((int) code);
 
 		      if (insn_operand_predicate[(int) code][2] != 0
 			  && ! ((*insn_operand_predicate[(int) code][2])
 				(op2, mode)))
 			op2 = copy_to_mode_reg (mode, op2);
 
-		      pat = GEN_FCN ((int) code) (target, xinner,
+		      pat = gen_insn (target, xinner,
 						  op2, opalign);
 		      if (pat)
 			{
@@ -10337,10 +10348,11 @@ expand_increment (exp, post, ignore)
 	  && (*insn_operand_predicate[icode][0]) (op0, mode)
 	  && (*insn_operand_predicate[icode][1]) (op0, mode))
 	{
+	  rtx (*gen_insn)(rtx, rtx, rtx) = GEN_FCN (icode);
 	  if (! (*insn_operand_predicate[icode][2]) (op1, mode))
 	    op1 = force_reg (mode, op1);
 
-	  return enqueue_insn (op0, GEN_FCN (icode) (op0, op0, op1));
+	  return enqueue_insn (op0, gen_insn (op0, op0, op1));
 	}
       if (icode != (int) CODE_FOR_nothing && GET_CODE (op0) == MEM)
 	{
@@ -10348,6 +10360,8 @@ expand_increment (exp, post, ignore)
 		      ? force_reg (Pmode, XEXP (op0, 0))
 		      : copy_to_reg (XEXP (op0, 0)));
 	  rtx temp, result;
+	  rtx (*gen_insn)(rtx, rtx, rtx) = GEN_FCN (icode);
+	  
 
 	  op0 = change_address (op0, VOIDmode, addr);
 	  temp = force_reg (GET_MODE (op0), op0);
@@ -10357,7 +10371,7 @@ expand_increment (exp, post, ignore)
 	  /* The increment queue is LIFO, thus we have to `queue'
 	     the instructions in reverse order.  */
 	  enqueue_insn (op0, gen_move_insn (op0, temp));
-	  result = enqueue_insn (temp, GEN_FCN (icode) (temp, temp, op1));
+	  result = enqueue_insn (temp, gen_insn (temp, temp, op1));
 	  return result;
 	}
     }

--- a/gcc_arm/loop.c
+++ b/gcc_arm/loop.c
@@ -7915,9 +7915,12 @@ check_dbra_loop (loop_end, insn_count, loop_start, loop_info)
 		    return 0;
 		  start_value
 		    = gen_rtx_PLUS (mode, comparison_value, offset);
-		  emit_insn_before ((GEN_FCN (icode)
+		    {
+			  rtx (*gen_insn)(rtx, rtx, rtx) = GEN_FCN (icode);
+			  emit_insn_before ((gen_insn
 				     (reg, comparison_value, offset)),
 				    loop_start);
+			}
 		  if (GET_CODE (comparison) == LE)
 		    final_value = gen_rtx_PLUS (mode, comparison_value,
 						GEN_INT (add_val));
@@ -7935,9 +7938,12 @@ check_dbra_loop (loop_end, insn_count, loop_start, loop_info)
 		    return 0;
 		  start_value
 		    = gen_rtx_MINUS (mode, comparison_value, initial_value);
-		  emit_insn_before ((GEN_FCN (icode)
-				     (reg, comparison_value, initial_value)),
-				    loop_start);
+		    {
+			  rtx (*gen_insn)(rtx, rtx, rtx) = GEN_FCN (icode);
+			  emit_insn_before ((gen_insn
+				(reg, comparison_value, initial_value)),
+				loop_start);
+			}
 		}
 	      else
 		/* We could handle the other cases too, but it'll be

--- a/gcc_arm/optabs.c
+++ b/gcc_arm/optabs.c
@@ -502,7 +502,10 @@ expand_binop (mode, binoptab, op0, op1, target, unsignedp, methods)
       if (! (*insn_operand_predicate[icode][0]) (temp, mode))
 	temp = gen_reg_rtx (mode);
 
-      pat = GEN_FCN (icode) (temp, xop0, xop1);
+        {
+          rtx (*gen_insn)(rtx, rtx, rtx) = (GEN_FCN (icode));
+          pat = gen_insn(temp, xop0, xop1);
+        }
       if (pat)
 	{
 	  /* If PAT is a multi-insn sequence, try to add an appropriate
@@ -1784,7 +1787,10 @@ expand_twoval_binop (binoptab, op0, op1, targ0, targ1, unsignedp)
 	  || ! (*insn_operand_predicate[icode][3]) (targ1, mode))
 	abort ();
 	
-      pat = GEN_FCN (icode) (targ0, xop0, xop1, targ1);
+        {
+          rtx (*gen_insn)(rtx, rtx, rtx, rtx) = (GEN_FCN (icode));
+          pat = gen_insn(targ0, xop0, xop1, targ1);
+        }
       if (pat)
 	{
 	  emit_insn (pat);
@@ -1888,7 +1894,10 @@ expand_unop (mode, unoptab, op0, target, unsignedp)
       if (! (*insn_operand_predicate[icode][0]) (temp, mode))
 	temp = gen_reg_rtx (mode);
 
-      pat = GEN_FCN (icode) (temp, xop0);
+    {
+      rtx (*gen_insn)(rtx, rtx) = (GEN_FCN (icode));
+      pat = gen_insn(temp, xop0);
+    }
       if (pat)
 	{
 	  if (GET_CODE (pat) == SEQUENCE
@@ -2261,7 +2270,10 @@ expand_complex_abs (mode, op0, target, unsignedp)
       if (! (*insn_operand_predicate[icode][0]) (temp, submode))
 	temp = gen_reg_rtx (submode);
 
-      pat = GEN_FCN (icode) (temp, xop0);
+        {
+          rtx (*gen_insn)(rtx, rtx) = (GEN_FCN (icode));
+          pat = gen_insn(temp, xop0);
+        }
       if (pat)
 	{
 	  if (GET_CODE (pat) == SEQUENCE
@@ -2427,7 +2439,10 @@ emit_unop_insn (icode, target, op0, code)
       || (flag_force_mem && GET_CODE (temp) == MEM))
     temp = gen_reg_rtx (GET_MODE (temp));
 
-  pat = GEN_FCN (icode) (temp, op0);
+    {
+      rtx (*gen_insn)(rtx, rtx) = (GEN_FCN (icode));
+      pat = gen_insn(temp, op0);
+    }
 
   if (GET_CODE (pat) == SEQUENCE && code != UNKNOWN)
     add_equal_note (pat, temp, code, op0, NULL_RTX);
@@ -2855,7 +2870,10 @@ emit_cmp_insn (x, y, comparison, size, mode, unsignedp, align)
 	  (x, insn_operand_mode[icode][0]))
 	x = copy_to_mode_reg (insn_operand_mode[icode][0], x);
 
-      emit_insn (GEN_FCN (icode) (x));
+      {
+        rtx (*gen_insn)(rtx) = (GEN_FCN (icode));
+        emit_insn (gen_insn(x));
+      }
       return;
     }
 
@@ -2878,7 +2896,11 @@ emit_cmp_insn (x, y, comparison, size, mode, unsignedp, align)
 	  (y, insn_operand_mode[icode][1]))
 	y = copy_to_mode_reg (insn_operand_mode[icode][1], y);
 
-      emit_insn (GEN_FCN (icode) (x, y));
+      {
+        rtx (*gen_insn)(rtx, rtx) = (GEN_FCN (icode));
+        emit_insn (gen_insn(x, y));
+      }
+
       return;
     }
 
@@ -3324,7 +3346,10 @@ emit_conditional_move (target, code, op0, op1, cmode, op2, op3, mode,
     /* This shouldn't happen.  */
     abort ();
   
-  insn = GEN_FCN (icode) (subtarget, comparison, op2, op3);
+    {
+      rtx (*gen_insn)(rtx, rtx, rtx, rtx) = (GEN_FCN (icode));
+      insn = gen_insn(subtarget, comparison, op2, op3);
+    }
 
   /* If that failed, then give up.  */
   if (insn == 0)
@@ -3378,7 +3403,10 @@ gen_add2_insn (x, y)
       || ! (*insn_operand_predicate[icode][2]) (y, insn_operand_mode[icode][2]))
     abort ();
 
-  return (GEN_FCN (icode) (x, x, y));
+  {
+    rtx (*gen_insn)(rtx, rtx, rtx) = (GEN_FCN (icode));
+    return gen_insn(x, x, y);
+  }
 }
 
 int
@@ -3401,7 +3429,10 @@ gen_sub2_insn (x, y)
       || ! (*insn_operand_predicate[icode][2]) (y, insn_operand_mode[icode][2]))
     abort ();
 
-  return (GEN_FCN (icode) (x, x, y));
+  {
+    rtx (*gen_insn)(rtx, rtx, rtx) = (GEN_FCN (icode));
+    return gen_insn(x, x, y);
+  }
 }
 
 int
@@ -3482,7 +3513,10 @@ gen_move_insn (x, y)
 	}
 	  
       insn_code = mov_optab->handlers[(int) tmode].insn_code;
-      return (GEN_FCN (insn_code) (x, y));
+      {
+        rtx (*gen_insn)(rtx, rtx) = (GEN_FCN (insn_code));
+        return gen_insn(x, y);
+      }
     }
 
   start_sequence ();
@@ -3513,7 +3547,8 @@ gen_extend_insn (x, y, mto, mfrom, unsignedp)
      enum machine_mode mto, mfrom;
      int unsignedp;
 {
-  return (GEN_FCN (extendtab[(int) mto][(int) mfrom][unsignedp]) (x, y));
+  rtx (*gen_insn)(rtx, rtx) = (GEN_FCN (extendtab[(int) mto][(int) mfrom][unsignedp]));
+  return (gen_insn (x, y));
 }
 
 /* can_fix_p and can_float_p say whether the target machine
@@ -4543,7 +4578,8 @@ gen_cond_trap (code, op1, op2, tcode)
       && cmp_optab->handlers[(int) mode].insn_code != CODE_FOR_nothing)
     {
       rtx insn;
-      emit_insn (GEN_FCN (cmp_optab->handlers[(int) mode].insn_code) (op1, op2));
+      rtx (*gen_insn)(rtx, rtx) = GEN_FCN (cmp_optab->handlers[(int) mode].insn_code);
+      emit_insn (gen_insn (op1, op2));
       PUT_CODE (trap_rtx, code);
       insn = gen_conditional_trap (trap_rtx, tcode);
       if (insn)

--- a/gcc_arm/regmove.c
+++ b/gcc_arm/regmove.c
@@ -110,7 +110,10 @@ gen_add3_insn (r0, r1, c)
 
   if ((*insn_operand_predicate[icode][1])(r1, insn_operand_mode[icode][1])
       && (*insn_operand_predicate[icode][2])(c, insn_operand_mode[icode][2]))
-    return (GEN_FCN (icode) (r0, r1, c));
+    {
+      rtx (*gen_insn)(rtx, rtx, rtx) = GEN_FCN (icode);
+      return (gen_insn (r0, r1, c));
+    }
 
   mcode = (int) mov_optab->handlers[(int) GET_MODE (r0)].insn_code;
   if (REGNO (r0) == REGNO (r1)
@@ -121,8 +124,14 @@ gen_add3_insn (r0, r1, c)
     return NULL_RTX;
 
   start_sequence ();
-  emit_insn (GEN_FCN (mcode) (r0, c));
-  emit_insn (GEN_FCN (icode) (r0, r0, r1));
+    {
+      rtx (*gen_insn)(rtx, rtx) = GEN_FCN (mcode);
+      emit_insn (gen_insn (r0, c));
+    }
+    {
+      rtx (*gen_insn)(rtx, rtx, rtx) = GEN_FCN (icode);
+      emit_insn (gen_insn (r0, r0, r1));
+    }
   s = gen_sequence ();
   end_sequence ();
   return s;
@@ -1571,7 +1580,10 @@ optimize_related_values (nregs, regmove_dump_file)
 	  || ! (*insn_operand_predicate[icode][1]) (reg, mode)
 	  || ! (*insn_operand_predicate[icode][2]) (const1_rtx, mode))
 	continue;
-      add = GEN_FCN (icode) (reg, reg, const1_rtx);
+        {
+          rtx (*gen_insn)(rtx, rtx, rtx) = GEN_FCN (icode);
+          add = gen_insn (reg, reg, const1_rtx);
+        }
       if (GET_CODE (add) == SEQUENCE)
 	continue;
       add = make_insn_raw (add);
@@ -3555,7 +3567,10 @@ regmove_profitable_p ()
 	      || ! (*insn_operand_predicate[icode][1]) (reg1, VOIDmode)
 	      || ! (*insn_operand_predicate[icode][2]) (reg2, VOIDmode))
 	    break;
-	  pat = GEN_FCN (icode) (reg0, reg1, reg2);
+    {
+      rtx (*gen_insn)(rtx, rtx, rtx) = GEN_FCN (icode);
+      pat = gen_insn (reg0, reg1, reg2);
+    }
 	  if (! pat)
 	    continue;
 	  if (GET_CODE (pat) == SEQUENCE)

--- a/gcc_arm/reload1.c
+++ b/gcc_arm/reload1.c
@@ -6942,7 +6942,8 @@ emit_reload_insns (chain)
 		    {
 		      if (icode != CODE_FOR_nothing)
 			{
-			  emit_insn (GEN_FCN (icode) (reloadreg, real_oldequiv,
+			  rtx (*gen_insn)(rtx, rtx, rtx) = GEN_FCN (icode);
+			  emit_insn (gen_insn (reloadreg, real_oldequiv,
 						      second_reload_reg));
 			  special = 1;
 			}
@@ -6955,10 +6956,11 @@ emit_reload_insns (chain)
 
 			  if (tertiary_icode != CODE_FOR_nothing)
 			    {
+				  rtx (*gen_insn)(rtx, rtx, rtx) = GEN_FCN (tertiary_icode);
 			      rtx third_reload_reg
 			        = reload_reg_rtx[reload_secondary_in_reload[secondary_reload]];
 
-			      emit_insn ((GEN_FCN (tertiary_icode)
+			      emit_insn ((gen_insn
 					  (second_reload_reg, real_oldequiv,
 					   third_reload_reg)));
 			    }
@@ -7220,8 +7222,11 @@ emit_reload_insns (chain)
 
 			  gen_reload (reloadreg, second_reloadreg,
 				      reload_opnum[j], reload_when_needed[j]);
-			  emit_insn ((GEN_FCN (tertiary_icode)
-				      (real_old, reloadreg, third_reloadreg)));
+			    {
+			      rtx (*gen_insn)(rtx, rtx, rtx) = GEN_FCN (tertiary_icode);
+			      emit_insn ((gen_insn
+					(real_old, reloadreg, third_reloadreg)));
+			    }
 			  special = 1;
 			}
 


### PR DESCRIPTION
An intermediate local value (cast to the appropriate signature) for lookups in the instruction generation jump table works around a code generation bug in macOS ARM64 clang that would cause their parameters to be pushed on the stack instead of passed in registers.