### PR TITLE
Add clean script

### DIFF
--- a/clean.sh
+++ b/clean.sh
@@ -1,4 +1,6 @@
 make -C gcc clean
+# || true is needed to keep going if the distclean fails, such as when no configure has been done before
+make -C gcc_arm distclean || true
 make -C libgcc clean
 make -C libc clean
 rm -f agbcc old_agbcc agbcc_arm libc.a libgcc.a

--- a/clean.sh
+++ b/clean.sh
@@ -1,0 +1,4 @@
+make -C gcc clean
+make -C libgcc clean
+make -C libc clean
+rm -f agbcc old_agbcc agbcc_arm libc.a libgcc.a


### PR DESCRIPTION
Adds a clean script like the other shell scripts to easily clean the agbcc build directory.
Ties in with #57