### PR TITLE
Add small fix for MSYS2 when building agbcc

### DIFF
--- a/gcc/Makefile
+++ b/gcc/Makefile
@@ -220,6 +220,7 @@ s-output : $(md_file) genoutput $(srcdir)/move-if-change
 
 genrtl.c genrtl.h : s-genrtl
 s-genrtl: gengenrtl $(srcdir)/move-if-change $(RTL_BASE_H)
+	chmod +x ./gengenrtl
 	./gengenrtl tmp-genrtl.h tmp-genrtl.c
 	$(srcdir)/move-if-change tmp-genrtl.h genrtl.h
 	$(srcdir)/move-if-change tmp-genrtl.c genrtl.c

--- a/gcc_arm/Makefile.in
+++ b/gcc_arm/Makefile.in
@@ -1628,6 +1628,7 @@ genrtl.c genrtl.h : s-genrtl
 	@true	# force gnu make to recheck modification times.
 
 s-genrtl: gengenrtl $(srcdir)/move-if-change $(RTL_BASE_H)
+	chmod +x ./gengenrtl
 	./gengenrtl tmp-genrtl.h tmp-genrtl.c
 	$(srcdir)/move-if-change tmp-genrtl.h genrtl.h
 	$(srcdir)/move-if-change tmp-genrtl.c genrtl.c


### PR DESCRIPTION
This PR fixes `Error 126` when attempting to build agbcc under MSYS2.
Fixes #46