### PR TITLE
Fix prologue issue

### DIFF
--- a/gcc/flags.h
+++ b/gcc/flags.h
@@ -454,3 +454,6 @@ extern int flag_hex_asm;
 /* Nonzero if generated DWARF debug info should be corrected rather than
    match the original (buggy) GCC 2.95.x output. */
 extern int flag_fixed_debug_line_info;
+
+/* Nonzero if prologue bug should be fixed.  */
+extern int flag_prologue_bugfix;

--- a/gcc/thumb.c
+++ b/gcc/thumb.c
@@ -717,8 +717,11 @@ far_jump_used_p()
     rtx insn;
 
 #ifndef OLD_COMPILER
-    if (current_function_has_far_jump)
-        return 1;
+    if (!flag_prologue_bugfix)
+    {
+        if (current_function_has_far_jump)
+            return 1;
+    }
 #endif
 
     for (insn = get_insns(); insn; insn = NEXT_INSN(insn))

--- a/gcc/toplev.c
+++ b/gcc/toplev.c
@@ -588,6 +588,9 @@ int flag_hex_asm = 0;
 /* Fix buggy DWARF line info generation.  */
 int flag_fixed_debug_line_info = 0;
 
+/* Fix prologue bug in new compiler.  */
+int flag_prologue_bugfix = 0;
+
 typedef struct
 {
     char *string;
@@ -729,6 +732,16 @@ lang_independent_options f_options[] =
      "Use hex instead of decimal in assembly output"},
     {"fix-debug-line", &flag_fixed_debug_line_info, 1,
      "Generate fixed DWARF line info"},
+    /* This flag fixes a bug in the newer agbcc version that causes `lr` to be
+       saved onto the stack in functions where it is not necessary. This is
+       needed to produce matching code for certain GBA games.
+       
+       This flag is defined under OLD_COMPILER to prevent a situation where a game
+       that uses both agbcc and old_agbcc (e.g., pokepinballrs) needs to maintain two
+       separate lists of flags depending on the compiler used for a specific file.
+       Otherwise, old_agbcc will throw an error.  */
+    {"prologue-bugfix", &flag_prologue_bugfix, 1,
+     "Prevent unnecessary saving of the lr register to the stack"},
 };
 
 #define NUM_ELEM(a)  (sizeof (a) / sizeof ((a)[0]))

--- a/gcc/toplev.c
+++ b/gcc/toplev.c
@@ -732,16 +732,13 @@ lang_independent_options f_options[] =
      "Use hex instead of decimal in assembly output"},
     {"fix-debug-line", &flag_fixed_debug_line_info, 1,
      "Generate fixed DWARF line info"},
+#ifndef OLD_COMPILER
     /* This flag fixes a bug in the newer agbcc version that causes `lr` to be
        saved onto the stack in functions where it is not necessary. This is
-       needed to produce matching code for certain GBA games.
-       
-       This flag is defined under OLD_COMPILER to prevent a situation where a game
-       that uses both agbcc and old_agbcc (e.g., pokepinballrs) needs to maintain two
-       separate lists of flags depending on the compiler used for a specific file.
-       Otherwise, old_agbcc will throw an error.  */
+       needed to produce matching code for certain GBA games.  */
     {"prologue-bugfix", &flag_prologue_bugfix, 1,
      "Prevent unnecessary saving of the lr register to the stack"},
+#endif
 };
 
 #define NUM_ELEM(a)  (sizeof (a) / sizeof ((a)[0]))


### PR DESCRIPTION
Supersedes and closes #35.
Supersedes #53.

This PR fixes an issue where some games (e.g., Pokémon Pinball: Ruby and Sapphire) have nonmatching functions under agbcc. This is because these games were compiled with a compiler revision that occasionally pushed LR onto the stack when unnecessary, but otherwise appears to be identical to agbcc.

~~Unlike #35 and #53, this version of -fprologue-bugfix is defined for OLD_COMPILER/old_agbcc. This is because it is an error to pass an invalid flag to old_agbcc. This causes an issue in pokepinballrs where some files are compiled with agbcc and some are compiled with old_agbcc, but both use the same set of flags. (That is to say, it is easier to define it for OLD_COMPILER than it is to update the Makefile. Especially since I do not know how I would update the Makefile to accomplish this.)~~

As the Makefile of pokepinballrs has been updated, this is now a copy of #35. Please see below for more information. This has been left open due to the CI issues on #35, but it is functionally the same.

I can be contacted at WhenGryphonsFly#2089 on Discord.