### PR TITLE
Add decomp.me CD

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,38 @@
+name: Build and release agbcc
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install dependencies (Ubuntu)
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-arm-none-eabi binutils-arm-none-eabi
+      - name: Build
+        shell: bash
+        run: |
+          sh build.sh
+      - name: Install to temp dir
+        shell: bash
+        run: |
+          sh install.sh TEMPDIR
+      - name: Create release archive
+        shell: bash
+        run: |
+          tar -czf agbcc.tar.gz TEMPDIR/*
+      - name: Upload archive
+        uses: actions/upload-artifact@v2
+        with:
+          name: agbcc.tar.gz
+          path: |
+            agbcc.tar.gz
+      - name: Update release
+        uses: johnwbyrd/update-release@v1.0.0
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          files: agbcc.tar.gz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,6 +67,6 @@ jobs:
           artifactErrorsFailBuild: true
           artifacts: agbcc.tar.gz
           commit: ${{ github.sha }}
-          makeLatest: true # This is a test
+          makeLatest: true
           tag: release
           token: ${{ secrets.GITHUB_TOKEN }} # Automatically created by the workflow with a lifetime of one hour

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Create release archive
         shell: bash
         run: |
-          tar -czf agbcc.tar.gz -C TEMPDIR/tools/agbcc *
+          tar -czf agbcc.tar.gz -C TEMPDIR/tools/agbcc $(ls .)
       - name: Upload archive
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Create release archive
         shell: bash
         run: |
-          tar -czf agbcc.tar.gz -C TEMPDIR/tools/agbcc $(ls .)
+          tar -C TEMPDIR/tools/agbcc -czf agbcc.tar.gz bin include lib
       - name: Upload archive
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Create release archive
         shell: bash
         run: |
-          tar -czf agbcc.tar.gz TEMPDIR/*
+          tar -czf agbcc.tar.gz -C TEMPDIR/tools/agbcc *
       - name: Upload archive
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
Currently, decomp.me uses the agbcc binary at https://github.com/ethteck/agbcc/releases/tag/master. This fork does not stay up-to-date with upstream. This means updates to agbcc (such as #64) are not automatically incorporated into decomp.me.

After a discussion at https://github.com/decompme/decomp.me/issues/820, it was decided that the best course of action was to update the CI here so that decomp.me can rely on pret's fork instead.

I have done some testing on my fork, but I welcome everyone to also test this before merging.