### PR TITLE
Restore -mtpcs-frame flag and behavior

### DIFF
--- a/gcc/thumb.h
+++ b/gcc/thumb.h
@@ -38,6 +38,8 @@ Boston, MA 02111-1307, USA.  */
 
 #define TARGET_VERSION  fputs (" (ARM/THUMB:generic)", stderr);
 
+#define THUMB_FLAG_BACKTRACE    		0x0002
+#define THUMB_FLAG_LEAF_BACKTRACE		0x0004
 #define ARM_FLAG_THUMB				0x1000	/* same as in arm.h */
 
 /* Nonzero if all call instructions should be indirect.  */
@@ -48,6 +50,9 @@ Boston, MA 02111-1307, USA.  */
 extern int target_flags;
 #define TARGET_DEFAULT          0 /* ARM_FLAG_THUMB */
 #define TARGET_THUMB_INTERWORK	(target_flags & ARM_FLAG_THUMB)
+#define TARGET_BACKTRACE	(leaf_function_p()			      \
+				 ? (target_flags & THUMB_FLAG_LEAF_BACKTRACE) \
+				 : (target_flags & THUMB_FLAG_BACKTRACE))
 
 #define TARGET_LONG_CALLS		(target_flags & ARM_FLAG_LONG_CALLS)
 
@@ -63,6 +68,10 @@ extern int target_flags;
   {"long-calls",		ARM_FLAG_LONG_CALLS,		\
    "Generate all call instructions as indirect calls"},		\
   {"no-long-calls",	       -ARM_FLAG_LONG_CALLS, ""},	\
+  {"tpcs-frame",		    THUMB_FLAG_BACKTRACE},	\
+  {"no-tpcs-frame",                -THUMB_FLAG_BACKTRACE},	\
+  {"tpcs-leaf-frame",	  	    THUMB_FLAG_LEAF_BACKTRACE},	\
+  {"no-tpcs-leaf-frame",           -THUMB_FLAG_LEAF_BACKTRACE},	\
   SUBTARGET_SWITCHES						\
   {"",                          TARGET_DEFAULT}         	\
 }


### PR DESCRIPTION
This restores the `-m(no-)tpcs-frame` and `-m(no-)tpcs-leaf-frame` flags and their associated behaviors, which were presumably removed from agbcc early on.

When enabled, these have the effect of producing extended function prologue and epilogues like this:

    sub     sp, sp, #16     @ Create stack backtrace structure
    push    {..., lr}
    add     r3, sp, #20
    str     r3, [sp, #8]
    mov     r3, pc
    str     r3, [sp, #16]
    mov     r3, fp
    str     r3, [sp, #4]
    mov     r3, lr
    str     r3, [sp, #12]
    add     r3, sp, #16
    mov     fp, r3          @ Backtrace structure created
    @ ...
    pop     {...}
    pop     {r0, r1, r2}
    mov     fp, r1
    mov     sp, r2
    bx      r0

This is known to be required to match exactly main.c in [fe6][fe6], [fe7][fe7jp] and [related projects][mgfembp].

[fe6]: https://github.com/StanHash/fe6
[fe7jp]: https://github.com/MokhaLeee/FireEmblem7J
[mgfembp]: https://github.com/StanHash/mgfembp