### PR TITLE
Fix build on Haiku OS

### DIFF
--- a/gcc/toplev.h
+++ b/gcc/toplev.h
@@ -21,6 +21,11 @@ Boston, MA 02111-1307, USA.  */
 #ifndef __GCC_TOPLEV_H__
 #define __GCC_TOPLEV_H__
 
+#include <setjmp.h>
+#ifndef _JBLEN
+# define _JBLEN (sizeof(jmp_buf)/sizeof(jmp_buf[0]))
+#endif
+
 union tree_node;
 struct rtx_def;
 
@@ -70,6 +75,7 @@ extern void error_for_asm		(struct rtx_def *, char *, ...)
 						ATTRIBUTE_PRINTF_2;
 extern void warning_for_asm		(struct rtx_def *, char *, ...)
 						ATTRIBUTE_PRINTF_2;
+
 #if defined (_JBLEN) || defined (setjmp)
 extern void set_float_handler (jmp_buf);
 extern int push_float_handler (jmp_buf, jmp_buf);

--- a/gcc_arm/toplev.h
+++ b/gcc_arm/toplev.h
@@ -21,6 +21,11 @@ Boston, MA 02111-1307, USA.  */
 #ifndef __GCC_TOPLEV_H__
 #define __GCC_TOPLEV_H__
 
+#include <setjmp.h>
+#ifndef _JBLEN
+# define _JBLEN (sizeof(jmp_buf)/sizeof(jmp_buf[0]))
+#endif
+
 #ifdef ANSI_PROTOTYPES
 union tree_node;
 struct rtx_def;


### PR DESCRIPTION
Building gcc and gcc_arm on Haiku OS fails with an implicit function definiton for set_float_handler. Adding an include for <setjmp.h> to toplev.h and making sure _JBLEN is defined makes sure the function gets defined properly.