### PR TITLE
create gh actions gcc version matrix and support gcc-14

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,37 +12,75 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-22.04
+            gcc-version: 11
+            experimental: false
+            deployable: true
+          - os: ubuntu-22.04
+            gcc-version: 12
+            experimental: false
+            deployable: false
+          - os: ubuntu-24.04
+            gcc-version: 12
+            experimental: false
+            deployable: false
+          - os: ubuntu-24.04
+            gcc-version: 13
+            experimental: false
+            deployable: false
+          - os: ubuntu-24.04
+            gcc-version: 14
+            experimental: true
+            deployable: false
+          - os: macos-14
+            gcc-version: 13
+            experimental: true
+            deployable: false
+          - os: macos-14
+            gcc-version: 14
+            experimental: true
+            deployable: false
+    runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.experimental }}
     steps:
 
       - name: Checkout
         uses: actions/checkout@main
 
-      - name: Install deps
+      - name: Install deps (Linux)
+        if: ${{ matrix.os == 'ubuntu-22.04' || matrix.os == 'ubuntu-24.04' }} 
         run: |
           sudo apt update
           sudo apt install gcc-arm-none-eabi binutils-arm-none-eabi
 
+      - name: Install deps (Mac)
+        if: ${{ matrix.os == 'macos-14' }}
+        run: |
+          brew install arm-none-eabi-binutils arm-none-eabi-gcc
+
       - name: Compile
-        run: sh build.sh
+        run: CC=gcc-${{matrix.gcc-version}} CXX=g++-${{matrix.gcc-version}} sh build.sh
 
       # No point in running the following steps if we are not deploying
       # See https://github.com/actions/runner/issues/1395 for why fromJSON() is needed
       - name: Install to temp dir
-        if: fromJSON(env.IS_DEPLOY)
+        if: ${{ fromJSON(env.IS_DEPLOY) && matrix.deployable }}
         shell: bash
         run: |
           mkdir TEMPDIR
           sh install.sh TEMPDIR
 
       - name: Create release archive
-        if: fromJSON(env.IS_DEPLOY)
+        if: ${{ fromJSON(env.IS_DEPLOY) && matrix.deployable }}
         shell: bash
         run: tar -C TEMPDIR/tools/agbcc -czf agbcc.tar.gz bin include lib
 
       - name: Upload archive
         uses: actions/upload-artifact@main
-        if: fromJSON(env.IS_DEPLOY)
+        if: ${{ fromJSON(env.IS_DEPLOY) && matrix.deployable }}
         with:
           name: agbcc.tar.gz
           path: agbcc.tar.gz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,34 +17,26 @@ jobs:
         include:
           - os: ubuntu-22.04
             gcc-version: 11
-            experimental: false
             deployable: true
           - os: ubuntu-22.04
             gcc-version: 12
-            experimental: false
             deployable: false
           - os: ubuntu-24.04
             gcc-version: 12
-            experimental: false
             deployable: false
           - os: ubuntu-24.04
             gcc-version: 13
-            experimental: false
             deployable: false
           - os: ubuntu-24.04
             gcc-version: 14
-            experimental: true
             deployable: false
           - os: macos-14
             gcc-version: 13
-            experimental: true
             deployable: false
           - os: macos-14
             gcc-version: 14
-            experimental: true
             deployable: false
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.experimental }}
     steps:
 
       - name: Checkout

--- a/gcc/Makefile
+++ b/gcc/Makefile
@@ -24,7 +24,7 @@ VPATH = $(srcdir)
 
 CC = gcc
 
-BASE_CFLAGS = -g -std=gnu11 -Werror-implicit-function-declaration
+BASE_CFLAGS = -g -std=gnu11 -Werror-implicit-function-declaration -Wno-error=incompatible-pointer-types
 
 INCLUDES = -I. -I$(srcdir)
 

--- a/gcc_arm/Makefile.in
+++ b/gcc_arm/Makefile.in
@@ -64,7 +64,7 @@ ALLOCA_FINISH = true
 XCFLAGS =
 TCFLAGS =
 # CYGNUS LOCAL nowarnings/law
-CFLAGS = -g -Werror-implicit-function-declaration
+CFLAGS = -g -Werror-implicit-function-declaration -Wno-error=incompatible-pointer-types
 BOOT_CFLAGS = -O2 $(CFLAGS)
 WARN_CFLAGS =
 # END CYGNUS LOCAL

--- a/gcc_arm/configure
+++ b/gcc_arm/configure
@@ -1138,7 +1138,7 @@ cat > conftest.$ac_ext << EOF
 #line 1139 "configure"
 #include "confdefs.h"
 
-main(){return(0);}
+int main(){return(0);}
 EOF
 if { (eval echo configure:1144: \"$ac_link\") 1>&5; (eval $ac_link) 2>&5; } && test -s conftest${ac_exeext}; then
   ac_cv_prog_cc_works=yes


### PR DESCRIPTION
this includes the fixes from https://github.com/pret/agbcc/pull/76, but addresses the ci issue differently

in https://github.com/pret/agbcc/pull/76
* building on mac was created as a separate job
* `*-latest` runners are still being used

in this PR:
* OS and gcc version are now handled via matrix
* `*-latest` is replaced with what `*-latest` currently is (`ubuntu-22.04` for linux and `macos-14` for mac)
  * note, i didn't change the deploy step away from `*-latest`

the matrix includes
| os | gcc versions |
| - | - |
| `ubuntu-22.04` | `gcc-11`, `gcc-12` |
| `ubuntu-24.04` | `gcc-12`, `gcc-13`, `gcc-14` |
| `macos-14` | `gcc-13`, `gcc-14` |

i addressed the issue of deploying build artifacts by adding a `deployable` bool to the matrix. as of making this PR, the builds that were being deployed were running on `gcc` (no version specified - i checked and it's 11) on `ubuntu-latest` (currently `22.04`), so i set the `deployable` flag to `true` for `ubuntu-22.04`/`gcc-11`. 