### PR TITLE
Fix Compilation on GCC 14 and 15

### DIFF
--- a/gcc_arm/Makefile.in
+++ b/gcc_arm/Makefile.in
@@ -64,7 +64,7 @@ ALLOCA_FINISH = true
 XCFLAGS =
 TCFLAGS =
 # CYGNUS LOCAL nowarnings/law
-CFLAGS = -g -Werror-implicit-function-declaration -Wno-error=incompatible-pointer-types
+CFLAGS = -g -Werror-implicit-function-declaration -Wno-error=incompatible-pointer-types -std=gnu11
 BOOT_CFLAGS = -O2 $(CFLAGS)
 WARN_CFLAGS =
 # END CYGNUS LOCAL


### PR DESCRIPTION
`-std=gnu17` needs to be passed to the `gcc_arm` build, in addition to `-Wno-incompatible-pointer-types`